### PR TITLE
System tests for whitelist validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 
 [project.optional-dependencies]
-server = ["fastapi", "uvicorn", "redis", "hiredis", "cachetools"]
+server = ["fastapi", "uvicorn", "redis", "hiredis", "cachetools", "pyyaml"]
 dev = [
     "copier",
     "httpx",

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -33,6 +33,7 @@ class ServerFilePaths:
     BEAMLINE_PARAMETERS = Path("/tests/test_data/beamline_parameters.txt")
     GOOD_JSON_FILE = Path("/tests/test_data/test_good_json.json")
     BAD_JSON_FILE = Path("/tests/test_data/test_bad_json")
+    FILE_IN_GOOD_DIR = Path("/tests/test_data/test_bad_json")
 
 
 TEST_WHITELIST_RESPONSE = f"""\

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,29 +1,46 @@
+from dataclasses import dataclass
 from pathlib import Path
 
 TEST_DATA_DIR_PATH = Path(f"{Path(__file__).parent}/test_data")
 
-TEST_BEAMLINE_PARAMETERS_PATH = TEST_DATA_DIR_PATH.joinpath("beamline_parameters.txt")
 
-TEST_BAD_JSON_PATH = TEST_DATA_DIR_PATH.joinpath("test_bad_json")
+@dataclass
+class TestDataPaths:
+    __test__ = False  # Stops pytest complaining about the class name
 
-TEST_GOOD_JSON_PATH = TEST_DATA_DIR_PATH.joinpath("test_good_json.json")
+    TEST_BEAMLINE_PARAMETERS_PATH = TEST_DATA_DIR_PATH.joinpath(
+        "beamline_parameters.txt"
+    )
 
-TEST_FILE_NOT_ON_WHITELIST_PATH = TEST_DATA_DIR_PATH.joinpath(
-    "test_file_not_on_whitelist.json"
-)
+    TEST_BAD_JSON_PATH = TEST_DATA_DIR_PATH.joinpath("test_bad_json")
 
-TEST_FILE_IN_GOOD_DIR = TEST_DATA_DIR_PATH.joinpath("good_dir/test_file")
+    TEST_GOOD_JSON_PATH = TEST_DATA_DIR_PATH.joinpath("test_good_json.json")
 
-TEST_FILE_IN_BAD_DIR = TEST_DATA_DIR_PATH.joinpath("bad_dir/test_file")
+    TEST_FILE_NOT_ON_WHITELIST_PATH = TEST_DATA_DIR_PATH.joinpath(
+        "test_file_not_on_whitelist.json"
+    )
 
-TEST_INVALID_FILE_PATH = TEST_DATA_DIR_PATH.joinpath("invalid_file")
+    TEST_FILE_IN_GOOD_DIR = TEST_DATA_DIR_PATH.joinpath("good_dir/test_file")
+
+    TEST_FILE_IN_BAD_DIR = TEST_DATA_DIR_PATH.joinpath("bad_dir/test_file")
+
+    TEST_INVALID_FILE_PATH = TEST_DATA_DIR_PATH.joinpath("invalid_file")
+
+
+# These are the file locations accessible from the server running in a container
+@dataclass
+class ServerFilePaths:
+    BEAMLINE_PARAMETERS = Path("/tests/test_data/beamline_parameters.txt")
+    GOOD_JSON_FILE = Path("/tests/test_data/test_good_json.json")
+    BAD_JSON_FILE = Path("/tests/test_data/test_bad_json")
+
 
 TEST_WHITELIST_RESPONSE = f"""\
 whitelist_files:
-  - {TEST_GOOD_JSON_PATH}
-  - {TEST_BAD_JSON_PATH}
-  - {TEST_BEAMLINE_PARAMETERS_PATH}
-  - {TEST_INVALID_FILE_PATH}
+  - {TestDataPaths.TEST_GOOD_JSON_PATH}
+  - {TestDataPaths.TEST_BAD_JSON_PATH}
+  - {TestDataPaths.TEST_BEAMLINE_PARAMETERS_PATH}
+  - {TestDataPaths.TEST_INVALID_FILE_PATH}
 
 whitelist_dirs:
   - {TEST_DATA_DIR_PATH.joinpath("good_dir")}

--- a/tests/system_tests/test_client.py
+++ b/tests/system_tests/test_client.py
@@ -14,14 +14,7 @@ from tests.constants import (
 
 SERVER_ADDRESS = "http://0.0.0.0:8555"
 
-"""For now, these tests require locally hosting the config server
-
-While in the python environment, run from the terminal:
-
-daq-config-server
-
-before running the tests
-"""
+# Docs for running these system tests will be added in https://github.com/DiamondLightSource/daq-config-server/issues/68
 
 
 @pytest.fixture

--- a/tests/system_tests/test_client.py
+++ b/tests/system_tests/test_client.py
@@ -88,25 +88,12 @@ def test_bad_json_gives_http_error_with_details(server: ConfigServer):
     server._log.error.assert_called_once_with(expected_detail)
 
 
-# See https://github.com/DiamondLightSource/daq-config-server/issues/96 for writing
-# these tests
-
-
-@pytest.mark.xfail
 @pytest.mark.requires_local_server
-def test_request_with_file_not_on_whitelist(): ...
-
-
-@pytest.mark.xfail
-@pytest.mark.requires_local_server
-def test_request_with_file_on_whitelist(): ...
-
-
-@pytest.mark.xfail
-@pytest.mark.requires_local_server
-def test_request_with_file_in_whitelist_dirs(): ...
-
-
-@pytest.mark.xfail
-@pytest.mark.requires_local_server
-def test_request_with_file_not_in_whitelist_dirs(): ...
+def test_request_with_file_not_on_whitelist(server: ConfigServer):
+    file_path = "/not_allowed_file_location"
+    with pytest.raises(
+        requests.exceptions.HTTPError, match=f"{file_path} is not a whitelisted file."
+    ):
+        server.get_file_contents(
+            file_path,
+        )

--- a/tests/system_tests/test_client.py
+++ b/tests/system_tests/test_client.py
@@ -8,9 +8,8 @@ import requests
 
 from daq_config_server.client import ConfigServer
 from tests.constants import (
-    TEST_BAD_JSON_PATH,
-    TEST_BEAMLINE_PARAMETERS_PATH,
-    TEST_GOOD_JSON_PATH,
+    ServerFilePaths,
+    TestDataPaths,
 )
 
 SERVER_ADDRESS = "http://0.0.0.0:8555"
@@ -32,13 +31,12 @@ def server():
 
 @pytest.mark.requires_local_server
 def test_read_unformatted_file_as_plain_text(server: ConfigServer):
-    file_path = TEST_BEAMLINE_PARAMETERS_PATH
-    with open(file_path) as f:
+    with open(TestDataPaths.TEST_BEAMLINE_PARAMETERS_PATH) as f:
         expected_response = f.read()
 
     assert (
         server.get_file_contents(
-            file_path,
+            ServerFilePaths.BEAMLINE_PARAMETERS,
         )
         == expected_response
     )
@@ -46,13 +44,12 @@ def test_read_unformatted_file_as_plain_text(server: ConfigServer):
 
 @pytest.mark.requires_local_server
 def test_read_file_as_bytes(server: ConfigServer):
-    file_path = TEST_BEAMLINE_PARAMETERS_PATH
-    with open(file_path, "rb") as f:
+    with open(TestDataPaths.TEST_BEAMLINE_PARAMETERS_PATH, "rb") as f:
         expected_response = f.read()
 
     assert (
         server.get_file_contents(
-            file_path,
+            ServerFilePaths.BEAMLINE_PARAMETERS,
             bytes,
         )
         == expected_response
@@ -61,13 +58,12 @@ def test_read_file_as_bytes(server: ConfigServer):
 
 @pytest.mark.requires_local_server
 def test_read_good_json_as_dict(server: ConfigServer):
-    file_path = TEST_GOOD_JSON_PATH
-    with open(file_path) as f:
+    with open(TestDataPaths.TEST_GOOD_JSON_PATH) as f:
         expected_response = json.loads(f.read())
 
     assert (
         server.get_file_contents(
-            file_path,
+            ServerFilePaths.GOOD_JSON_FILE,
             dict[Any, Any],
         )
         == expected_response
@@ -76,7 +72,7 @@ def test_read_good_json_as_dict(server: ConfigServer):
 
 @pytest.mark.requires_local_server
 def test_bad_json_gives_http_error_with_details(server: ConfigServer):
-    file_path = TEST_BAD_JSON_PATH
+    file_path = ServerFilePaths.BAD_JSON_FILE
     file_name = os.path.basename(file_path)
     expected_detail = (
         f"Failed to convert {file_name} to application/json. "

--- a/tests/unit_tests/test_api.py
+++ b/tests/unit_tests/test_api.py
@@ -10,14 +10,7 @@ from fastapi.testclient import TestClient
 from daq_config_server import app
 from daq_config_server.app import ValidAcceptHeaders
 from daq_config_server.constants import ENDPOINTS
-from tests.constants import (
-    TEST_BEAMLINE_PARAMETERS_PATH,
-    TEST_FILE_IN_BAD_DIR,
-    TEST_FILE_IN_GOOD_DIR,
-    TEST_FILE_NOT_ON_WHITELIST_PATH,
-    TEST_GOOD_JSON_PATH,
-    TEST_INVALID_FILE_PATH,
-)
+from tests.constants import TestDataPaths
 
 
 @pytest.fixture
@@ -46,7 +39,7 @@ async def _assert_get_and_response(
 
 
 async def test_get_configuration_on_plain_text_file(mock_app: TestClient):
-    file_path = TEST_BEAMLINE_PARAMETERS_PATH
+    file_path = TestDataPaths.TEST_BEAMLINE_PARAMETERS_PATH
     with open(file_path) as f:
         expected_contents = f.read()
 
@@ -64,7 +57,7 @@ async def test_get_configuration_on_plain_text_file(mock_app: TestClient):
 
 
 async def test_get_configuration_raw_bytes(mock_app: TestClient):
-    file_path = TEST_BEAMLINE_PARAMETERS_PATH
+    file_path = TestDataPaths.TEST_BEAMLINE_PARAMETERS_PATH
     with open(file_path, "rb") as f:
         expected_contents = f.read()
     expected_type = ValidAcceptHeaders.RAW_BYTES
@@ -83,7 +76,7 @@ async def test_get_configuration_raw_bytes(mock_app: TestClient):
 
 
 def test_get_configuration_exception_on_invalid_file(mock_app: TestClient):
-    file_path = TEST_INVALID_FILE_PATH
+    file_path = TestDataPaths.TEST_INVALID_FILE_PATH
     response = mock_app.get(
         f"{ENDPOINTS.CONFIG}/{file_path}", headers=ACCEPT_HEADER_DEFAULT
     )
@@ -91,7 +84,7 @@ def test_get_configuration_exception_on_invalid_file(mock_app: TestClient):
 
 
 async def test_get_configuration_on_json_file(mock_app: TestClient):
-    file_path = TEST_GOOD_JSON_PATH
+    file_path = TestDataPaths.TEST_GOOD_JSON_PATH
     with open(file_path) as f:
         expected_contents = json.load(f)
     expected_type = ValidAcceptHeaders.JSON
@@ -128,25 +121,25 @@ async def test_health_check_returns_code_200(
 
 
 def test_validate_path_against_whitelist_on_valid_file(mock_app: TestClient):
-    file_path = TEST_BEAMLINE_PARAMETERS_PATH
+    file_path = TestDataPaths.TEST_BEAMLINE_PARAMETERS_PATH
     response = mock_app.get(f"{ENDPOINTS.CONFIG}/{file_path}")
     assert response.status_code == status.HTTP_200_OK
 
 
 def test_validate_path_against_whitelist_on_invalid_file(mock_app: TestClient):
-    file_path = TEST_FILE_NOT_ON_WHITELIST_PATH
+    file_path = TestDataPaths.TEST_FILE_NOT_ON_WHITELIST_PATH
     response = mock_app.get(f"{ENDPOINTS.CONFIG}/{file_path}")
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 def test_validate_path_against_whitelist_on_file_in_invalid_dir(mock_app: TestClient):
-    file_path = TEST_FILE_IN_BAD_DIR
+    file_path = TestDataPaths.TEST_FILE_IN_BAD_DIR
     response = mock_app.get(f"{ENDPOINTS.CONFIG}/{file_path}")
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 def test_validate_path_against_whitelist_on_file_in_valid_dir(mock_app: TestClient):
-    file_path = TEST_FILE_IN_GOOD_DIR
+    file_path = TestDataPaths.TEST_FILE_IN_GOOD_DIR
     response = mock_app.get(f"{ENDPOINTS.CONFIG}/{file_path}")
     assert response.status_code == status.HTTP_200_OK
 


### PR DESCRIPTION
Fixes #96 

After fixing existing system tests, I noticed a lot of the blank tests I'd added were already covered. This PR just adds ones extra test, as well as fixing the others to work with the whitelist

To test:
- Outside of the dev container, get a local running image of the config server by running `daq-config-server/deployment/build_and_push.sh -r -b`
- Inside the dev container, run `pytest .` with a terminal in `daq-config-server`
- Confirm all tests pass
