### PR TITLE
Fix message spacing

### DIFF
--- a/src/daq_config_server/app.py
+++ b/src/daq_config_server/app.py
@@ -115,9 +115,11 @@ def get_configuration(
     if not path_is_whitelisted(file_path):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"{file_path} is not a whitelisted file. Please make sure it \
-            exists in https://raw.githubusercontent.com/DiamondLightSource/\
-            daq-config-server/refs/heads/main/whitelist.yaml",
+            detail=(
+                f"{file_path} is not a whitelisted file. Please make sure it "
+                "exists in https://raw.githubusercontent.com/DiamondLightSource/"
+                "daq-config-server/refs/heads/main/whitelist.yaml"
+            ),
         )
 
     if not file_path.is_file():

--- a/src/daq_config_server/client.py
+++ b/src/daq_config_server/client.py
@@ -114,8 +114,8 @@ class ConfigServer:
 
         if content_type != accept_header:
             self._log.warning(
-                f"Server failed to parse the file as requested. Requested \
-                {accept_header} but response came as content-type {content_type}"
+                f"Server failed to parse the file as requested. Requested "
+                f"{accept_header} but response came as content-type {content_type}"
             )
 
         try:


### PR DESCRIPTION
Previous string formatting was resulting in error messages with large spaces in the middle of a sentence