### PR TITLE
Add MX Beamlines to Whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -15,3 +15,6 @@ whitelist_dirs:
 - /dls_sw/i04/software/daq_configuration/
 - /dls_sw/i19-1/software/daq_configuration/
 - /dls_sw/i19-2/software/daq_configuration/
+- /dls_sw/i23/software/daq_configuration/
+- /dls_sw/i24/software/daq_configuration/
+- /dls_sw/i04-1/software/daq_configuration/


### PR DESCRIPTION
To review
- Confirm that added directories are safe for read-only access to anyone on the diamond network