### PR TITLE
Allow untyped dicts in get_file_contents

### DIFF
--- a/tests/system_tests/test_client.py
+++ b/tests/system_tests/test_client.py
@@ -64,6 +64,20 @@ def test_read_good_json_as_dict(server: ConfigServer):
 
 
 @pytest.mark.requires_local_server
+def test_read_good_json_as_untyped_dict(server: ConfigServer):
+    with open(TestDataPaths.TEST_GOOD_JSON_PATH) as f:
+        expected_response = json.loads(f.read())
+
+    assert (
+        server.get_file_contents(
+            ServerFilePaths.GOOD_JSON_FILE,
+            dict,
+        )
+        == expected_response
+    )
+
+
+@pytest.mark.requires_local_server
 def test_bad_json_gives_http_error_with_details(server: ConfigServer):
     file_path = ServerFilePaths.BAD_JSON_FILE
     file_name = os.path.basename(file_path)

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -109,3 +109,17 @@ def test_bad_responses_with_details_raises_error(mock_request: MagicMock):
     with pytest.raises(requests.exceptions.HTTPError):
         server.get_file_contents(test_path)
     server._log.error.assert_called_once_with(detail)
+
+
+@patch("daq_config_server.client.requests.get")
+def test_get_file_contents_with_untyped_dict(mock_request: MagicMock):
+    content_type = ValidAcceptHeaders.JSON
+    good_json = '{"good_dict":"test"}'
+    mock_request.return_value = make_test_response(
+        good_json, content_type=content_type, json_value=good_json
+    )
+    url = "url"
+    server = ConfigServer(url)
+    assert server.get_file_contents(test_path, desired_return_type=dict) == {
+        "good_dict": "test"
+    }

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -8,7 +8,12 @@ from fastapi import status
 from httpx import Response
 
 from daq_config_server.app import ValidAcceptHeaders
-from daq_config_server.client import ConfigServer, TypeConversionException
+from daq_config_server.client import (
+    ConfigServer,
+    T,
+    TypeConversionException,
+    _get_mime_type,
+)
 from daq_config_server.constants import ENDPOINTS
 from daq_config_server.testing import make_test_response
 
@@ -123,3 +128,17 @@ def test_get_file_contents_with_untyped_dict(mock_request: MagicMock):
     assert server.get_file_contents(test_path, desired_return_type=dict) == {
         "good_dict": "test"
     }
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        (dict, ValidAcceptHeaders.JSON),
+        (dict[str, bytes], ValidAcceptHeaders.JSON),
+        (dict[Any, Any], ValidAcceptHeaders.JSON),
+        (str, ValidAcceptHeaders.PLAIN_TEXT),
+        (bytes, ValidAcceptHeaders.RAW_BYTES),
+    ],
+)
+def test_get_mime_type(input: type[T], expected: ValidAcceptHeaders):
+    assert _get_mime_type(input) == expected


### PR DESCRIPTION
There was a bug where using `get_file_contents(file_path, dict)` would fail, since the mapping dictionary didn't recognise `dict` as a `dict[Any, Any]`. After this change you can do `get_file_contents` with typed or untyped dicts