### PR TITLE
Whitelist config files

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -7,6 +7,7 @@
 whitelist_files:
 - /tests/test_data/beamline_parameters.txt
 # The following filepaths should be un-whitelisted once they've been moved to **/daq_configuration/
+# See https://jira.diamond.ac.uk/browse/MXGDA-4204
 - /dls_sw/i03/software/gda/configurations/i03-config/xml/jCameraManZoomLevels.xml
 - /dls_sw/i04/software/bluesky/scratch/jCameraManZoomLevels.xml
 - /dls_sw/i19-1/software/gda_versions/gda/config/xml/jCameraManZoomLevels.xml


### PR DESCRIPTION
Related to https://github.com/DiamondLightSource/mx-bluesky/issues/1228 and https://github.com/DiamondLightSource/daq-config-server/issues/127

Some config files are still in gda directories. Until they've been moved to `**/daq_configuration/`, they need to be added to the whitelist so the config server can see them.