### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/daq_config_server/app.py
+++ b/src/daq_config_server/app.py
@@ -108,7 +108,7 @@ def get_configuration(
 
     if not file_path.is_absolute():
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=(f"Requested filepath {file_path} must be an absolute path"),
         )
 
@@ -148,7 +148,7 @@ def get_configuration(
                     content = f.read()
     except Exception as e:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=(
                 f"Failed to convert {file_name} to {accept}. "
                 "Try requesting this file as a different type."

--- a/tests/unit_tests/test_api.py
+++ b/tests/unit_tests/test_api.py
@@ -111,7 +111,7 @@ async def test_get_configuration_gives_http_422_on_failed_conversion(
     response = mock_app.get(
         f"{ENDPOINTS.CONFIG}/{file_path}", headers=ACCEPT_HEADER_DEFAULT
     )
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 async def test_health_check_returns_code_200(
@@ -147,4 +147,4 @@ def test_validate_path_against_whitelist_on_file_in_valid_dir(mock_app: TestClie
 def test_get_configuration_on_non_absolute_filepath(mock_app: TestClient):
     file_path = "relative_path"
     response = mock_app.get(f"{ENDPOINTS.CONFIG}/{file_path}")
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT


### PR DESCRIPTION
CI was failing due to this warning, see https://github.com/DiamondLightSource/daq-config-server/actions/runs/19506947473/job/55835687940