### PR TITLE
File based whitelist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,7 @@ COPY --from=build /python /python
 COPY --from=build /app/.venv /app/.venv
 ENV PATH=/app/.venv/bin:$PATH
 
+# Copy the default configuration files
+COPY helm/daq-config-server/whitelist.yaml /etc/config/whitelist.yaml
+
 ENTRYPOINT ["daq-config-server"]

--- a/docs/explanations/whitelist_info.md
+++ b/docs/explanations/whitelist_info.md
@@ -1,6 +1,6 @@
 # Whitelist Security
 
-The centrally-hosted config server is running with the same permissions as the `dls-dasc` group. Since this service currently doesn't have authentication and has `/dls_sw` mounted, we have introduced a whitelist to ensure that nothing sensitve gets read. Most importantly, **nothing confidential should be added to the whitelist**. This includes any experimental data and files containing credentials.
+The centrally-hosted config server is running with the same permissions as the `dls-dasc` group. Since this service currently doesn't have authentication and has `/dls_sw` mounted, we have introduced whitelists to ensure that nothing sensitive gets read. Most importantly, **nothing confidential should be added to the whitelist**. This includes any experimental data and files containing credentials.
 
 This service was designed primarily to read beamline configuration files, like lookup tables and key-value variables. However, as long the file is safe for **anyone** to read, it can be safely added to the whitelist.
 

--- a/docs/how-to/config-server-guide.md
+++ b/docs/how-to/config-server-guide.md
@@ -28,6 +28,16 @@ A request for `str` or `bytes` will fetch the raw file with no conversion.
 
 For [security reasons](../explanations/whitelist_info.md), only files existing on the [whitelist](https://github.com/DiamondLightSource/daq-config-server/blob/main/whitelist.yaml) can be read. Please make a PR to add a file to the whitelist. If unsure, please ask in the #daq-config-server slack channel or create a GitHub issue. To make the config-server as quick to use as possible, the server will check any requests against the `whitelist.yaml` file on **the main branch of the repository**, rather than the whitelist in the latest release. The server will check for updates every 5 minutes.
 
+# File-based whitelist
+
+As an alternative to a remote single centrally-maintained whitelist, it is possible to configure a local file-based whitelist, which can be
+specified in the AppConfig YAML, for example:
+
+```yaml
+
+
+```
+
 # Reading sensitive information
 
 If you need to read a file which contains sensitive information, or `dls-dasc` doesn't have the permissions to read your file, you should encrypt this file as a [sealed secret](https://github.com/bitnami-labs/sealed-secrets) on your beamline cluster, and mount this in your BlueAPI service.

--- a/docs/how-to/config-server-guide.md
+++ b/docs/how-to/config-server-guide.md
@@ -24,18 +24,19 @@ Converters can be used to turn a file into a standard format server-side, reduci
 
 A request for `str` or `bytes` will fetch the raw file with no conversion.
 
-# Adding files to the whitelist
+# Whitelisting files
 
-For [security reasons](../explanations/whitelist_info.md), only files existing on the [whitelist](https://github.com/DiamondLightSource/daq-config-server/blob/main/whitelist.yaml) can be read. Please make a PR to add a file to the whitelist. If unsure, please ask in the #daq-config-server slack channel or create a GitHub issue. To make the config-server as quick to use as possible, the server will check any requests against the `whitelist.yaml` file on **the main branch of the repository**, rather than the whitelist in the latest release. The server will check for updates every 5 minutes.
+For [security reasons](../explanations/whitelist_info.md), only files existing on the [whitelist](https://github.com/DiamondLightSource/daq-config-server/blob/main/whitelist.yaml) can be read. Older versions of the daq-config-server periodically polled the main branch of this repository to fetch updates to their whitelist. However, file-based configuration is now preferred and this shared whitelist is now deprecated. Beamlines using such older releases of the config server should when they next upgrade their daq-config-server to a newer release add their beamline-specific whitelist configuration to their beamline configmap and submit a PR to this project to remove their entries from the legacy whitelist after deploying their updated server.
+
+Similarly, beamlines that decide to migrate from the shared config server to a beamline-specific deployment should also inform the daq-config-server maintainers and submit a PR to remove their whitelist entries from the site-wide configuration. 
 
 # File-based whitelist
 
-As an alternative to a remote single centrally-maintained whitelist, it is possible to configure a local file-based whitelist, which can be
-specified in the AppConfig YAML, for example:
+The whitelist is configured using a yaml file, by default the location is ``/etc/config/whitelist.yaml``. The location of the whitelist is configurable in the AppConfig YAML, for example:
 
 ```yaml
-
-
+whitelist:
+  config_file: "/path/to/my/whitelist.yaml"
 ```
 
 # Reading sensitive information

--- a/helm/daq-config-server/whitelist.yaml
+++ b/helm/daq-config-server/whitelist.yaml
@@ -1,25 +1,15 @@
-# This whitelist file is now DEPRECATED
-# It is retained solely for the use of legacy beamline daq-config-server deployments which
-# do not have their own whitelist configuration files and instead poll GitHub as described below.
-# When these beamline deployments are next updated, they should remove their whitelist entries from
-# this file and instead update their beamline-specific configmap with their own dedicated whitelist
-
-# The deployed config server will check requests against the whitelist from the MAIN branch of the repo.
-# It will check for updates of this file every 10 minutes - no new releases or restarts are required.
-# To add a file or directory to the whitelist, please adjust this file and create a PR
-
+# This whitelist defines the configuration files permitted for access by the site-wide
+# config server at daq-config.diamond.ac.uk
+# Beamlines with their own beamline-specific daq-config-server should define their own whitelists
+# in the configmap for their own individual deployment.
 
 #For long-term configuration files
 whitelist_files:
 - /tests/test_data/beamline_parameters.txt
 # The following filepaths should be un-whitelisted once they've been moved to **/daq_configuration/
 # See https://jira.diamond.ac.uk/browse/MXGDA-4204
-- /dls_sw/i03/software/gda/configurations/i03-config/xml/jCameraManZoomLevels.xml
-- /dls_sw/i04/software/bluesky/scratch/jCameraManZoomLevels.xml
 - /dls_sw/i19-1/software/gda_versions/gda/config/xml/jCameraManZoomLevels.xml
 - /dls_sw/i24/software/gda_versions/gda/config/xml/jCameraManZoomLevels.xml
-- /dls_sw/i03/software/gda_versions/var/display.configuration
-- /dls_sw/i04/software/bluesky/scratch/display.configuration
 - /dls_sw/i23/software/aithre/aithre_display.configuration
 - /dls_sw/i24/software/gda_versions/var/display.configuration
 - /dls_sw/i15-1/software/gda_var/xpdfLocalParameters.xml
@@ -28,8 +18,6 @@ whitelist_files:
 whitelist_dirs:
 - /tests/test_data/
 - /dls_sw/i02-1/software/daq_configuration/
-- /dls_sw/i03/software/daq_configuration/
-- /dls_sw/i04/software/daq_configuration/
 - /dls_sw/i19-1/software/daq_configuration/
 - /dls_sw/i19-2/software/daq_configuration/
 - /dls_sw/i23/software/daq_configuration/

--- a/helm/daq-config-server/whitelist.yaml
+++ b/helm/daq-config-server/whitelist.yaml
@@ -11,6 +11,7 @@ whitelist_files:
 - /dls_sw/i19-1/software/gda_versions/gda/config/xml/jCameraManZoomLevels.xml
 - /dls_sw/i24/software/gda_versions/gda/config/xml/jCameraManZoomLevels.xml
 - /dls_sw/i23/software/aithre/aithre_display.configuration
+- /dls_sw/i23/software/aithre/aithre_oav.xml
 - /dls_sw/i24/software/gda_versions/var/display.configuration
 - /dls_sw/i15-1/software/gda_var/xpdfLocalParameters.xml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ addopts = """
 markers = """
     requires_local_server: mark a test which requires locally hosting the config server
     requires_deployed_server: mark a test which requires talking to the deployed config server
-    use_threading: mark a test which will kickoff the background thread in WhitelistFetcher
 """
 
 # https://iscinumpy.gitlab.io/post/bound-version-constraints/#watch-for-warnings

--- a/src/daq_config_server/app/_config.py
+++ b/src/daq_config_server/app/_config.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 from daq_config_server.app._log import LoggingConfig
 
 CONFIG_PATH = "/etc/config/config.yaml"
+DEFAULT_WHITELIST_PATH = "/etc/config/whitelist.yaml"
 
 
 class UvicornConfig(BaseModel):
@@ -13,7 +14,7 @@ class UvicornConfig(BaseModel):
 
 
 class WhitelistConfig(BaseModel):
-    config_file: str | None = None
+    config_file: str = DEFAULT_WHITELIST_PATH
 
 
 class AppConfig(BaseModel):

--- a/src/daq_config_server/app/_config.py
+++ b/src/daq_config_server/app/_config.py
@@ -12,9 +12,14 @@ class UvicornConfig(BaseModel):
     workers: int = 2
 
 
+class WhitelistConfig(BaseModel):
+    config_file: str | None = None
+
+
 class AppConfig(BaseModel):
     logging: LoggingConfig = LoggingConfig()
     uvicorn: UvicornConfig = UvicornConfig()
+    whitelist: WhitelistConfig = WhitelistConfig()
 
 
 def load_config() -> AppConfig:

--- a/src/daq_config_server/app/_whitelist.py
+++ b/src/daq_config_server/app/_whitelist.py
@@ -34,7 +34,10 @@ class WhitelistFetcher:
 
     @abstractmethod
     def _fetch(self) -> str:
-        pass  # pragma: no cover
+        """Implement in derived classes to fetch the whitelist.
+        Returns:
+            str: The whitelist YAML
+        """
 
     def _fetch_and_update(self):
         text = self._fetch()

--- a/src/daq_config_server/app/_whitelist.py
+++ b/src/daq_config_server/app/_whitelist.py
@@ -1,18 +1,22 @@
 import atexit
 import logging
 import time
-from functools import cache
+from abc import abstractmethod
 from pathlib import Path
 from threading import Event, Thread
 
 import requests
 import yaml
 
+from daq_config_server.app._config import WhitelistConfig
+
 LOGGER = logging.getLogger(__name__)
 
 
 WHITELIST_REFRESH_RATE_S = 300
 WHITELIST_URL = "https://raw.githubusercontent.com/DiamondLightSource/daq-config-server/refs/heads/main/whitelist.yaml"
+
+_whitelist: "WhitelistFetcher"
 
 
 class WhitelistFetcher:
@@ -28,10 +32,13 @@ class WhitelistFetcher:
         )
         self.update_in_background_thread.start()
 
+    @abstractmethod
+    def _fetch(self):
+        pass
+
     def _fetch_and_update(self):
-        response = requests.get(WHITELIST_URL)
-        response.raise_for_status()
-        data = yaml.safe_load(response.text)
+        text = self._fetch()
+        data = yaml.safe_load(text)
         self.whitelist_files = {Path(p) for p in data.get("whitelist_files")}
         self.whitelist_dirs = {Path(p) for p in data.get("whitelist_dirs")}
 
@@ -57,11 +64,39 @@ class WhitelistFetcher:
         self.update_in_background_thread.join(timeout=1)
 
 
-@cache
+class UrlWhitelist(WhitelistFetcher):
+    """Read the whitelist from the main branch of this repo from github"""
+
+    def _fetch(self) -> str:
+        response = requests.get(WHITELIST_URL)
+        response.raise_for_status()
+        text = response.text
+        return text
+
+
+class FilesystemWhitelist(WhitelistFetcher):
+    """Read the whitelist from a configuration file"""
+
+    def __init__(self, path: Path):
+        self._path = path
+        super().__init__()
+
+    def _fetch(self) -> str:
+        with self._path.open() as f:
+            return f.read()
+
+
 def get_whitelist() -> WhitelistFetcher:
-    fetcher = WhitelistFetcher()
-    atexit.register(fetcher.stop)
-    return fetcher
+    return _whitelist
+
+
+def init_whitelist(config: WhitelistConfig) -> None:
+    global _whitelist
+    if config.config_file:
+        _whitelist = FilesystemWhitelist(Path(config.config_file))
+    else:
+        _whitelist = UrlWhitelist()
+    atexit.register(_whitelist.stop)
 
 
 def path_is_whitelisted(file_path: Path) -> bool:

--- a/src/daq_config_server/app/_whitelist.py
+++ b/src/daq_config_server/app/_whitelist.py
@@ -5,7 +5,6 @@ from abc import abstractmethod
 from pathlib import Path
 from threading import Event, Thread
 
-import requests
 import yaml
 
 from daq_config_server.app._config import WhitelistConfig
@@ -14,13 +13,12 @@ LOGGER = logging.getLogger(__name__)
 
 
 WHITELIST_REFRESH_RATE_S = 300
-WHITELIST_URL = "https://raw.githubusercontent.com/DiamondLightSource/daq-config-server/refs/heads/main/whitelist.yaml"
 
 _whitelist: "WhitelistFetcher"
 
 
 class WhitelistFetcher:
-    """Read the whitelist from the main branch of this repo from github, and check for
+    """Read the whitelist from the implementation-specific source, and check for
     updates every 5 minutes. This lets the deployed server see updates to the whitelist
     without requiring a new release or a restart"""
 
@@ -48,7 +46,7 @@ class WhitelistFetcher:
     def _initial_load(self):
         try:
             self._fetch_and_update()
-            LOGGER.info("Successfully read whitelist from GitHub.")
+            LOGGER.info("Successfully read whitelist.")
         except Exception as e:
             LOGGER.error(f"Initial whitelist load failed: {e}")
             raise RuntimeError("Failed to load whitelist during initialization.") from e
@@ -65,16 +63,6 @@ class WhitelistFetcher:
     def stop(self):
         self._stop.set()
         self.update_in_background_thread.join(timeout=1)
-
-
-class UrlWhitelist(WhitelistFetcher):
-    """Read the whitelist from the main branch of this repo from github"""
-
-    def _fetch(self) -> str:
-        response = requests.get(WHITELIST_URL)
-        response.raise_for_status()
-        text = response.text
-        return text
 
 
 class FilesystemWhitelist(WhitelistFetcher):
@@ -95,10 +83,7 @@ def get_whitelist() -> WhitelistFetcher:
 
 def init_whitelist(config: WhitelistConfig) -> None:
     global _whitelist
-    if config.config_file:
-        _whitelist = FilesystemWhitelist(Path(config.config_file))
-    else:
-        _whitelist = UrlWhitelist()
+    _whitelist = FilesystemWhitelist(Path(config.config_file))
     atexit.register(_whitelist.stop)
 
 

--- a/src/daq_config_server/app/_whitelist.py
+++ b/src/daq_config_server/app/_whitelist.py
@@ -33,7 +33,7 @@ class WhitelistFetcher:
         self.update_in_background_thread.start()
 
     @abstractmethod
-    def _fetch(self):
+    def _fetch(self) -> str:
         pass
 
     def _fetch_and_update(self):

--- a/src/daq_config_server/app/_whitelist.py
+++ b/src/daq_config_server/app/_whitelist.py
@@ -34,7 +34,7 @@ class WhitelistFetcher:
 
     @abstractmethod
     def _fetch(self) -> str:
-        pass
+        pass  # pragma: no cover
 
     def _fetch_and_update(self):
         text = self._fetch()

--- a/src/daq_config_server/app/_whitelist.py
+++ b/src/daq_config_server/app/_whitelist.py
@@ -1,7 +1,6 @@
 import atexit
 import logging
 import time
-from abc import abstractmethod
 from pathlib import Path
 from threading import Event, Thread
 
@@ -14,15 +13,16 @@ LOGGER = logging.getLogger(__name__)
 
 WHITELIST_REFRESH_RATE_S = 300
 
-_whitelist: "WhitelistFetcher"
+_whitelist: "FilesystemWhitelist"
 
 
-class WhitelistFetcher:
-    """Read the whitelist from the implementation-specific source, and check for
+class FilesystemWhitelist:
+    """Read the whitelist from a configuration file, and check for
     updates every 5 minutes. This lets the deployed server see updates to the whitelist
     without requiring a new release or a restart"""
 
-    def __init__(self):
+    def __init__(self, path: Path):
+        self._path = path
         self._initial_load()
         self._stop = Event()
         self.update_in_background_thread = Thread(
@@ -30,12 +30,13 @@ class WhitelistFetcher:
         )
         self.update_in_background_thread.start()
 
-    @abstractmethod
     def _fetch(self) -> str:
-        """Implement in derived classes to fetch the whitelist.
+        """Read the whitelist from a configuration file.
         Returns:
             str: The whitelist YAML
         """
+        with self._path.open() as f:
+            return f.read()
 
     def _fetch_and_update(self):
         text = self._fetch()
@@ -65,19 +66,7 @@ class WhitelistFetcher:
         self.update_in_background_thread.join(timeout=1)
 
 
-class FilesystemWhitelist(WhitelistFetcher):
-    """Read the whitelist from a configuration file"""
-
-    def __init__(self, path: Path):
-        self._path = path
-        super().__init__()
-
-    def _fetch(self) -> str:
-        with self._path.open() as f:
-            return f.read()
-
-
-def get_whitelist() -> WhitelistFetcher:
+def get_whitelist() -> FilesystemWhitelist:
     return _whitelist
 
 

--- a/src/daq_config_server/app/api.py
+++ b/src/daq_config_server/app/api.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
 
 import uvicorn
 from fastapi import FastAPI, Request
@@ -9,7 +10,7 @@ from fastapi.responses import Response
 from ._config import load_config
 from ._log import set_up_logging
 from ._routes import router
-from ._whitelist import init_whitelist
+from ._whitelist import init_whitelist, get_whitelist
 
 LOGGER = logging.getLogger(__name__)
 
@@ -24,9 +25,18 @@ async def log_request_details(
     return await call_next(request)
 
 
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    config = load_config()
+    init_whitelist(config.whitelist)
+    yield
+    get_whitelist().stop()
+
+
 app = FastAPI(
     title="DAQ config server",
     description="For reading files stored on /dls_sw from another container",
+    lifespan=lifespan,
 )
 
 app.middleware("http")(log_request_details)
@@ -46,7 +56,6 @@ def main():
     config = load_config()
 
     set_up_logging(config.logging)
-    init_whitelist(config.whitelist)
 
     uvicorn.run(
         "daq_config_server.app.api:app",

--- a/src/daq_config_server/app/api.py
+++ b/src/daq_config_server/app/api.py
@@ -10,7 +10,7 @@ from fastapi.responses import Response
 from ._config import load_config
 from ._log import set_up_logging
 from ._routes import router
-from ._whitelist import init_whitelist, get_whitelist
+from ._whitelist import get_whitelist, init_whitelist
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/daq_config_server/app/api.py
+++ b/src/daq_config_server/app/api.py
@@ -9,6 +9,7 @@ from fastapi.responses import Response
 from ._config import load_config
 from ._log import set_up_logging
 from ._routes import router
+from ._whitelist import init_whitelist
 
 LOGGER = logging.getLogger(__name__)
 
@@ -45,6 +46,7 @@ def main():
     config = load_config()
 
     set_up_logging(config.logging)
+    init_whitelist(config.whitelist)
 
     uvicorn.run(
         "daq_config_server.app.api:app",

--- a/tests/test_data/whitelist.yaml
+++ b/tests/test_data/whitelist.yaml
@@ -1,0 +1,13 @@
+# The deployed config server will check requests against the whitelist from the MAIN branch of the repo. 
+# It will check for updates of this file every 10 minutes - no new releases or restarts are required.
+# To add a file or directory to the whitelist, please adjust this file and create a PR
+
+
+#For long-term configuration files
+whitelist_files:
+- /tests/test_data/beamline_parameters.txt
+
+
+#For long-term directories with frequently changing files
+whitelist_dirs:
+- /tests/test_data/good_dir

--- a/tests/unit_tests/app/test_api.py
+++ b/tests/unit_tests/app/test_api.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from daq_config_server.__main__ import __version__, main
 from daq_config_server.app import main as main_app
+from daq_config_server.app._config import WhitelistConfig
 from daq_config_server.app.api import app, log_request_details
 from tests.constants import TEST_CONFIG_PATH
 
@@ -15,6 +16,12 @@ from tests.constants import TEST_CONFIG_PATH
 @pytest.fixture
 def mock_app():
     return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def mock_init_whitelist():
+    with patch("daq_config_server.app.api.init_whitelist") as patched_fn:
+        yield patched_fn
 
 
 async def test_log_request_details():
@@ -65,3 +72,11 @@ def test_logging_with_no_mounted_config(
     # If config file doesn't exist, graylog option is disabled by default
     main_app()
     mock_graylog_setup.assert_not_called()
+
+
+@patch("daq_config_server.app.api.uvicorn.run")
+def test_main_app_calls_init_whitelist(
+    mock_run: MagicMock, mock_init_whitelist: MagicMock
+):
+    main_app()
+    mock_init_whitelist.assert_called_once_with(WhitelistConfig())

--- a/tests/unit_tests/app/test_api.py
+++ b/tests/unit_tests/app/test_api.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 from daq_config_server.__main__ import __version__, main
 from daq_config_server.app import main as main_app
 from daq_config_server.app._config import WhitelistConfig
-from daq_config_server.app.api import app, log_request_details, lifespan
+from daq_config_server.app.api import app, lifespan, log_request_details
 from tests.constants import TEST_CONFIG_PATH
 
 
@@ -77,9 +77,7 @@ def test_logging_with_no_mounted_config(
 @patch("daq_config_server.app.api.get_whitelist")
 @patch("daq_config_server.app.api.uvicorn.run")
 async def test_app_lifespan_calls_init_whitelist(
-    mock_run: MagicMock,
-    mock_get_whitelist: MagicMock,
-    mock_init_whitelist: MagicMock
+    mock_run: MagicMock, mock_get_whitelist: MagicMock, mock_init_whitelist: MagicMock
 ):
     async with lifespan(MagicMock()):
         mock_init_whitelist.assert_called_once_with(WhitelistConfig())

--- a/tests/unit_tests/app/test_api.py
+++ b/tests/unit_tests/app/test_api.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 from daq_config_server.__main__ import __version__, main
 from daq_config_server.app import main as main_app
 from daq_config_server.app._config import WhitelistConfig
-from daq_config_server.app.api import app, log_request_details
+from daq_config_server.app.api import app, log_request_details, lifespan
 from tests.constants import TEST_CONFIG_PATH
 
 
@@ -74,9 +74,13 @@ def test_logging_with_no_mounted_config(
     mock_graylog_setup.assert_not_called()
 
 
+@patch("daq_config_server.app.api.get_whitelist")
 @patch("daq_config_server.app.api.uvicorn.run")
-def test_main_app_calls_init_whitelist(
-    mock_run: MagicMock, mock_init_whitelist: MagicMock
+async def test_app_lifespan_calls_init_whitelist(
+    mock_run: MagicMock,
+    mock_get_whitelist: MagicMock,
+    mock_init_whitelist: MagicMock
 ):
-    main_app()
-    mock_init_whitelist.assert_called_once_with(WhitelistConfig())
+    async with lifespan(MagicMock()):
+        mock_init_whitelist.assert_called_once_with(WhitelistConfig())
+    mock_get_whitelist.return_value.stop.assert_called_once()

--- a/tests/unit_tests/app/test_whitelist.py
+++ b/tests/unit_tests/app/test_whitelist.py
@@ -1,4 +1,5 @@
 import threading
+from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -29,7 +30,9 @@ def mock_log_info():
 
 
 @pytest.fixture()
-def inject_whitelist(request: FixtureRequest, mock_log_info: MagicMock):
+def inject_whitelist(
+    request: FixtureRequest, mock_log_info: MagicMock
+) -> Generator[None, None, None]:
     with (
         patch("daq_config_server.app._whitelist.Thread"),
         patch("daq_config_server.app._whitelist.WhitelistFetcher.stop"),
@@ -39,7 +42,7 @@ def inject_whitelist(request: FixtureRequest, mock_log_info: MagicMock):
 
 
 @pytest.mark.parametrize("inject_whitelist", [LEGACY_SHARED_WHITELIST], indirect=True)
-def test_legacy_whitelist_contains_expected_data(inject_whitelist):
+def test_legacy_whitelist_contains_expected_data(inject_whitelist: None):
     whitelist = get_whitelist()
     expected_files = {
         Path("/tests/test_data/beamline_parameters.txt"),
@@ -53,7 +56,7 @@ def test_legacy_whitelist_contains_expected_data(inject_whitelist):
 
 
 @pytest.mark.parametrize("inject_whitelist", [DEFAULT_WHITELIST], indirect=True)
-def test_default_whitelist_contains_expected_data(inject_whitelist):
+def test_default_whitelist_contains_expected_data(inject_whitelist: None):
     whitelist = get_whitelist()
     expected_files = {
         Path("/tests/test_data/beamline_parameters.txt"),
@@ -68,7 +71,7 @@ def test_default_whitelist_contains_expected_data(inject_whitelist):
 @pytest.mark.parametrize("inject_whitelist", [DEFAULT_WHITELIST], indirect=True)
 def test_initial_load_on_successful_fetch(
     mock_log_info: MagicMock,
-    inject_whitelist,
+    inject_whitelist: None,
 ):
     mock_log_info.assert_called_once_with("Successfully read whitelist.")
 

--- a/tests/unit_tests/app/test_whitelist.py
+++ b/tests/unit_tests/app/test_whitelist.py
@@ -4,7 +4,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from daq_config_server.app._whitelist import WhitelistFetcher, get_whitelist
+from daq_config_server.app._config import WhitelistConfig
+from daq_config_server.app._whitelist import (
+    WhitelistFetcher,
+    get_whitelist,
+    init_whitelist,
+)
 
 """The tests in this file will read directly from the whitelist.yaml in the current
 branch"""
@@ -25,7 +30,7 @@ def test_fetch_and_update_contructs_whitelist_given_yaml():
 
 @patch("daq_config_server.app._whitelist.LOGGER.info")
 def test_initial_load_on_sucessful_fetch(mock_log_info: MagicMock):
-    get_whitelist()
+    init_whitelist(WhitelistConfig())
     mock_log_info.assert_called_once_with("Successfully read whitelist from GitHub.")
 
 
@@ -38,7 +43,7 @@ def test_initial_load_on_failed_fetch(mock_log_error: MagicMock):
         with pytest.raises(
             RuntimeError, match="Failed to load whitelist during initialization."
         ):
-            get_whitelist()
+            init_whitelist(WhitelistConfig())
 
     mock_log_error.assert_called_once_with("Initial whitelist load failed: blah")
 
@@ -74,6 +79,17 @@ def test_periodically_update_whitelist_on_successful_update(mock_log: MagicMock)
             logging_event.set()
 
     mock_log.info.side_effect = complete_logging_event_on_current_message
-    get_whitelist()
+    init_whitelist(WhitelistConfig())
     assert logging_event.wait(timeout=0.1)
     mock_log.error.assert_not_called()
+
+
+def test_file_based_whitelist():
+    whitelist_path = "tests/test_data/whitelist.yaml"
+    config = WhitelistConfig(config_file=whitelist_path)
+    init_whitelist(config)
+    whitelist = get_whitelist()
+    assert whitelist.whitelist_files == {
+        Path("/tests/test_data/beamline_parameters.txt")
+    }
+    assert whitelist.whitelist_dirs == {Path("/tests/test_data/good_dir")}

--- a/tests/unit_tests/app/test_whitelist.py
+++ b/tests/unit_tests/app/test_whitelist.py
@@ -3,9 +3,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from _pytest.fixtures import FixtureRequest
 
 from daq_config_server.app._config import WhitelistConfig
 from daq_config_server.app._whitelist import (
+    FilesystemWhitelist,
     WhitelistFetcher,
     get_whitelist,
     init_whitelist,
@@ -14,8 +16,30 @@ from daq_config_server.app._whitelist import (
 """The tests in this file will read directly from the whitelist.yaml in the current
 branch"""
 
+LEGACY_SHARED_WHITELIST = Path(__file__).resolve().parents[3] / "whitelist.yaml"
+DEFAULT_WHITELIST = (
+    Path(__file__).resolve().parents[3] / "helm/daq-config-server/whitelist.yaml"
+)
 
-def test_fetch_and_update_contructs_whitelist_given_yaml():
+
+@pytest.fixture()
+def mock_log_info():
+    with patch("daq_config_server.app._whitelist.LOGGER.info") as mock_fn:
+        yield mock_fn
+
+
+@pytest.fixture()
+def inject_whitelist(request: FixtureRequest, mock_log_info: MagicMock):
+    with (
+        patch("daq_config_server.app._whitelist.Thread"),
+        patch("daq_config_server.app._whitelist.WhitelistFetcher.stop"),
+    ):
+        init_whitelist(WhitelistConfig(config_file=str(request.param)))
+        yield
+
+
+@pytest.mark.parametrize("inject_whitelist", [LEGACY_SHARED_WHITELIST], indirect=True)
+def test_legacy_whitelist_contains_expected_data(inject_whitelist):
     whitelist = get_whitelist()
     expected_files = {
         Path("/tests/test_data/beamline_parameters.txt"),
@@ -28,10 +52,25 @@ def test_fetch_and_update_contructs_whitelist_given_yaml():
     assert expected_dirs.issubset(whitelist.whitelist_dirs)
 
 
-@patch("daq_config_server.app._whitelist.LOGGER.info")
-def test_initial_load_on_sucessful_fetch(mock_log_info: MagicMock):
-    init_whitelist(WhitelistConfig())
-    mock_log_info.assert_called_once_with("Successfully read whitelist from GitHub.")
+@pytest.mark.parametrize("inject_whitelist", [DEFAULT_WHITELIST], indirect=True)
+def test_default_whitelist_contains_expected_data(inject_whitelist):
+    whitelist = get_whitelist()
+    expected_files = {
+        Path("/tests/test_data/beamline_parameters.txt"),
+    }
+    expected_dirs = {
+        Path("/tests/test_data/"),
+    }
+    assert expected_files.issubset(whitelist.whitelist_files)
+    assert expected_dirs.issubset(whitelist.whitelist_dirs)
+
+
+@pytest.mark.parametrize("inject_whitelist", [DEFAULT_WHITELIST], indirect=True)
+def test_initial_load_on_successful_fetch(
+    mock_log_info: MagicMock,
+    inject_whitelist,
+):
+    mock_log_info.assert_called_once_with("Successfully read whitelist.")
 
 
 @patch("daq_config_server.app._whitelist.LOGGER.error")
@@ -43,12 +82,12 @@ def test_initial_load_on_failed_fetch(mock_log_error: MagicMock):
         with pytest.raises(
             RuntimeError, match="Failed to load whitelist during initialization."
         ):
-            init_whitelist(WhitelistConfig())
+            FilesystemWhitelist(DEFAULT_WHITELIST)
 
     mock_log_error.assert_called_once_with("Initial whitelist load failed: blah")
 
 
-@pytest.mark.use_threading
+@patch("daq_config_server.app._whitelist.WHITELIST_REFRESH_RATE_S", new=0)
 @patch("daq_config_server.app._whitelist.LOGGER.error")
 def test_periodically_update_whitelist_on_failed_update(mock_log_error: MagicMock):
     with patch.object(WhitelistFetcher, "_initial_load"):
@@ -68,10 +107,11 @@ def test_periodically_update_whitelist_on_failed_update(mock_log_error: MagicMoc
             mock_log_error.assert_called_with("Failed to update whitelist: blah")
 
 
-@pytest.mark.use_threading
 @patch("daq_config_server.app._whitelist.LOGGER")
 @patch("daq_config_server.app._whitelist.WHITELIST_REFRESH_RATE_S", new=0)
-def test_periodically_update_whitelist_on_successful_update(mock_log: MagicMock):
+def test_periodically_update_whitelist_on_successful_update(
+    mock_log: MagicMock,
+):
     logging_event = threading.Event()
 
     def complete_logging_event_on_current_message(msg: str):
@@ -79,9 +119,12 @@ def test_periodically_update_whitelist_on_successful_update(mock_log: MagicMock)
             logging_event.set()
 
     mock_log.info.side_effect = complete_logging_event_on_current_message
-    init_whitelist(WhitelistConfig())
-    assert logging_event.wait(timeout=0.1)
-    mock_log.error.assert_not_called()
+    whitelist = FilesystemWhitelist(DEFAULT_WHITELIST)
+    try:
+        assert logging_event.wait(timeout=0.1)
+        mock_log.error.assert_not_called()
+    finally:
+        whitelist.stop()
 
 
 def test_file_based_whitelist():

--- a/tests/unit_tests/app/test_whitelist.py
+++ b/tests/unit_tests/app/test_whitelist.py
@@ -9,7 +9,6 @@ from _pytest.fixtures import FixtureRequest
 from daq_config_server.app._config import WhitelistConfig
 from daq_config_server.app._whitelist import (
     FilesystemWhitelist,
-    WhitelistFetcher,
     get_whitelist,
     init_whitelist,
 )
@@ -35,7 +34,7 @@ def inject_whitelist(
 ) -> Generator[None, None, None]:
     with (
         patch("daq_config_server.app._whitelist.Thread"),
-        patch("daq_config_server.app._whitelist.WhitelistFetcher.stop"),
+        patch("daq_config_server.app._whitelist.FilesystemWhitelist.stop"),
     ):
         init_whitelist(WhitelistConfig(config_file=str(request.param)))
         yield
@@ -79,7 +78,7 @@ def test_initial_load_on_successful_fetch(
 @patch("daq_config_server.app._whitelist.LOGGER.error")
 def test_initial_load_on_failed_fetch(mock_log_error: MagicMock):
     with patch.object(
-        WhitelistFetcher, "_fetch_and_update", side_effect=Exception("blah")
+        FilesystemWhitelist, "_fetch_and_update", side_effect=Exception("blah")
     ):
         # Expect a RuntimeError because _initial_load wraps _fetch_and_update failures
         with pytest.raises(
@@ -93,13 +92,13 @@ def test_initial_load_on_failed_fetch(mock_log_error: MagicMock):
 @patch("daq_config_server.app._whitelist.WHITELIST_REFRESH_RATE_S", new=0)
 @patch("daq_config_server.app._whitelist.LOGGER.error")
 def test_periodically_update_whitelist_on_failed_update(mock_log_error: MagicMock):
-    with patch.object(WhitelistFetcher, "_initial_load"):
+    with patch.object(FilesystemWhitelist, "_initial_load"):
         with patch.object(
-            WhitelistFetcher,
+            FilesystemWhitelist,
             "_fetch_and_update",
             side_effect=Exception("blah"),
         ):
-            whitelist = WhitelistFetcher()
+            whitelist = FilesystemWhitelist(Path("/test/path"))
 
             # Stop the thread immediately to prevent looping
             whitelist.stop()

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from _pytest.tmpdir import TempPathFactory
 from pytest import FixtureRequest
 
 from daq_config_server.app._config import WhitelistConfig
@@ -16,7 +17,7 @@ DEFAULT_WHITELIST = (
 
 
 @pytest.fixture(scope="session")
-def tmp_whitelist(tmp_path_factory):
+def tmp_whitelist(tmp_path_factory: TempPathFactory) -> Path:
     tmp_whitelist = tmp_path_factory.mktemp("yaml") / "test_whitelist.yaml"
     with tmp_whitelist.open("w") as whitelist_stream:
         whitelist_stream.write(TEST_WHITELIST_RESPONSE)

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 from pytest import FixtureRequest
 
-from daq_config_server.app._whitelist import get_whitelist
+from daq_config_server.app._whitelist import UrlWhitelist, get_whitelist
 from daq_config_server.testing._utils import make_test_response
 from tests.constants import TEST_WHITELIST_RESPONSE
 
@@ -25,17 +25,18 @@ def test_friendly_whitelist(request: FixtureRequest):
                 content=TEST_WHITELIST_RESPONSE
             )
 
-        if request.node.get_closest_marker("use_threading"):  # type: ignore
-            with patch(
-                "daq_config_server.app._whitelist.WHITELIST_REFRESH_RATE_S", new=0
-            ):
-                yield
-                get_whitelist().stop()
-        else:
-            with (
-                patch("daq_config_server.app._whitelist.Thread"),
-                patch("daq_config_server.app._whitelist.WhitelistFetcher.stop"),
-            ):
-                yield
-
-    get_whitelist.cache_clear()
+        with patch(
+            "daq_config_server.app._whitelist._whitelist", UrlWhitelist(), create=True
+        ):
+            if request.node.get_closest_marker("use_threading"):  # type: ignore
+                with patch(
+                    "daq_config_server.app._whitelist.WHITELIST_REFRESH_RATE_S", new=0
+                ):
+                    yield
+                    get_whitelist().stop()
+            else:
+                with (
+                    patch("daq_config_server.app._whitelist.Thread"),
+                    patch("daq_config_server.app._whitelist.WhitelistFetcher.stop"),
+                ):
+                    yield

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -4,39 +4,34 @@ from unittest.mock import patch
 import pytest
 from pytest import FixtureRequest
 
-from daq_config_server.app._whitelist import UrlWhitelist, get_whitelist
-from daq_config_server.testing._utils import make_test_response
+from daq_config_server.app._config import WhitelistConfig
+from daq_config_server.app._whitelist import (
+    init_whitelist,
+)
 from tests.constants import TEST_WHITELIST_RESPONSE
 
-WHITELIST_PATH = Path(__file__).resolve().parents[2] / "whitelist.yaml"
+DEFAULT_WHITELIST = (
+    Path(__file__).resolve().parents[2] / "helm/daq-config-server/whitelist.yaml"
+)
+
+
+@pytest.fixture(scope="session")
+def tmp_whitelist(tmp_path_factory):
+    tmp_whitelist = tmp_path_factory.mktemp("yaml") / "test_whitelist.yaml"
+    with tmp_whitelist.open("w") as whitelist_stream:
+        whitelist_stream.write(TEST_WHITELIST_RESPONSE)
+    return tmp_whitelist
 
 
 @pytest.fixture(autouse=True)
-def test_friendly_whitelist(request: FixtureRequest):
-    # Don't launch threads unless we really need to since it slows down testing
-
-    with patch("daq_config_server.app._whitelist.requests.get") as mock_request:
-        if "test_whitelist.py" in str(request.path):
-            with open(WHITELIST_PATH) as f:
-                whitelist_contents = f.read()
-            mock_request.return_value = make_test_response(content=whitelist_contents)
-        else:
-            mock_request.return_value = make_test_response(
-                content=TEST_WHITELIST_RESPONSE
-            )
-
-        with patch(
-            "daq_config_server.app._whitelist._whitelist", UrlWhitelist(), create=True
+def patch_whitelist_fetch(tmp_whitelist: Path, request: FixtureRequest):
+    test_module_path = request.path
+    if "test_whitelist.py" not in str(test_module_path):
+        with (
+            patch("daq_config_server.app._whitelist.Thread"),
+            patch("daq_config_server.app._whitelist.WhitelistFetcher.stop"),
         ):
-            if request.node.get_closest_marker("use_threading"):  # type: ignore
-                with patch(
-                    "daq_config_server.app._whitelist.WHITELIST_REFRESH_RATE_S", new=0
-                ):
-                    yield
-                    get_whitelist().stop()
-            else:
-                with (
-                    patch("daq_config_server.app._whitelist.Thread"),
-                    patch("daq_config_server.app._whitelist.WhitelistFetcher.stop"),
-                ):
-                    yield
+            init_whitelist(WhitelistConfig(config_file=str(tmp_whitelist)))
+            yield
+    else:
+        yield

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -30,7 +30,7 @@ def patch_whitelist_fetch(tmp_whitelist: Path, request: FixtureRequest):
     if "test_whitelist.py" not in str(test_module_path):
         with (
             patch("daq_config_server.app._whitelist.Thread"),
-            patch("daq_config_server.app._whitelist.WhitelistFetcher.stop"),
+            patch("daq_config_server.app._whitelist.FilesystemWhitelist.stop"),
         ):
             init_whitelist(WhitelistConfig(config_file=str(tmp_whitelist)))
             yield

--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -21,6 +21,7 @@ whitelist_files:
 - /dls_sw/i03/software/gda_versions/var/display.configuration
 - /dls_sw/i04/software/bluesky/scratch/display.configuration
 - /dls_sw/i23/software/aithre/aithre_display.configuration
+- /dls_sw/i23/software/aithre/aithre_oav.xml
 - /dls_sw/i24/software/gda_versions/var/display.configuration
 - /dls_sw/i15-1/software/gda_var/xpdfLocalParameters.xml
 


### PR DESCRIPTION
Addresses
* #175 

This extends the `AppConfig` yaml to allow the whitelist to be defined by specifying a YAML file to be loaded instead of being fetched from github:

```
whitelist:
  config_file: /etc/config/whitelist.yaml
```

* Github-url-based whitelist is now no longer supported. Legacy whitelist.yaml is retained until all currently deployed config servers are upgraded to use config files.
* The default configuration is as per central config server at daq-config.diamond.ac.uk and baked into the container image


