### PR TITLE
Add the path to i19-shared config files for the optics to whitelist

### DIFF
--- a/helm/daq-config-server/whitelist.yaml
+++ b/helm/daq-config-server/whitelist.yaml
@@ -22,6 +22,7 @@ whitelist_dirs:
 - /dls_sw/i02-1/software/daq_configuration/
 - /dls_sw/i19-1/software/daq_configuration/
 - /dls_sw/i19-2/software/daq_configuration/
+- /dls_sw/i19-1/software/i19-acquisition/i19-shared
 - /dls_sw/i23/software/daq_configuration/
 - /dls_sw/i24/software/daq_configuration/
 - /dls_sw/i04-1/software/daq_configuration/


### PR DESCRIPTION
I19 has config files for the optics that are shared between the two hutches. While both `daq-configuration` paths will have links to the common location, it would be more correct to have the config server read it in the first place without relying on the links