### PR TITLE
Remove references to i03 paths from central configuration

### DIFF
--- a/helm/daq-config-server/converter_map.yaml
+++ b/helm/daq-config-server/converter_map.yaml
@@ -4,8 +4,6 @@
   converter: UndulatorEnergyGapLookupTable
 - path: "/dls_sw/i23/software/aithre/aithre_display.configuration"
   converter: DisplayConfig
-- path: "/dls_sw/i03/software/gda_versions/var/display.configuration"
-  converter: DisplayConfig
 - path: "/dls_sw/i04/software/bluesky/scratch/display.configuration"
   converter: DisplayConfig
 - path: "/dls_sw/i19-1/software/daq_configuration/domain/display.configuration"
@@ -14,8 +12,6 @@
   converter: DisplayConfig
 - path: "/dls_sw/i24/software/gda_versions/var/display.configuration"
   converter: DisplayConfig
-- path: "/dls_sw/i03/software/gda/configurations/i03-config/xml/jCameraManZoomLevels.xml"
-  converter: Xml
 - path: "/dls_sw/i04/software/bluesky/scratch/jCameraManZoomLevels.xml"
   converter: Xml
 - path: "/dls_sw/i19-1/software/gda_versions/gda/config/xml/jCameraManZoomLevels.xml"
@@ -24,12 +20,8 @@
   converter: Xml
 - path: "/dls_sw/i24/software/gda_versions/gda/config/xml/jCameraManZoomLevels.xml"
   converter: Xml
-- path: "/dls_sw/i03/software/daq_configuration/domain/beamlineParameters"
-  converter: BeamlineParameters
 - path: "/dls_sw/i04/software/daq_configuration/domain/beamlineParameters"
   converter: BeamlineParameters
-- path: "/dls_sw/i03/software/daq_configuration/lookup/DetDistToBeamXYConverter.txt"
-  converter: DetectorXYLookupTable
 - path: "/dls_sw/i04/software/daq_configuration/lookup/DetDistToBeamXYConverter.txt"
   converter: DetectorXYLookupTable
 - path: "/dls_sw/i04-1/software/daq_configuration/lookup/DetDistToBeamXYConverter.txt"
@@ -42,20 +34,12 @@
   converter: DetectorXYLookupTable
 - path: "/dls_sw/i24/software/daq_configuration/lookup/DetDistToBeamXYConverterE9M.txt"
   converter: DetectorXYLookupTable
-- path: "/dls_sw/i03/software/daq_configuration/lookup/BeamLineEnergy_DCM_Pitch_converter.txt"
-  converter: BeamlinePitchLookupTable
-- path: "/dls_sw/i03/software/daq_configuration/lookup/BeamLineEnergy_DCM_Roll_converter.txt"
-  converter: BeamlineRollLookupTable
-- path: "/dls_sw/i03/software/daq_configuration/lookup/BeamLine_Undulator_toGap.txt"
-  converter: UndulatorEnergyGapLookupTable
 - path: "/dls_sw/i04/software/daq_configuration/lookup/BeamLine_Undulator_toGap.txt"
   converter: UndulatorEnergyGapLookupTable
 - path: "/dls_sw/i09-1/software/gda/workspace_git/gda-diamond.git/configurations/i09-1-shared/lookupTables/IIDCalibrationTable.txt"
   converter: I09UndulatorHuEnergyGapLut
 - path: "/dls_sw/i04/software/daq_configuration/domain/domain.properties"
   converter: I04FeatureSettings
-- path: "/dls_sw/i03/software/daq_configuration/domain/domain.properties"
-  converter: HyperionFeatureSettings
 - path: "/dls_sw/i15-1/software/gda_var/xpdfLocalParameters.xml"
   converter: TemperatureControllersConfig
 - path: "/dls_sw/i15-1/software/daq_configuration/xpdf_crystal_lut.txt"

--- a/tests/unit_tests/app/test_whitelist.py
+++ b/tests/unit_tests/app/test_whitelist.py
@@ -48,7 +48,7 @@ def test_legacy_whitelist_contains_expected_data(inject_whitelist: None):
     }
     expected_dirs = {
         Path("/tests/test_data/"),
-        Path("/dls_sw/i03/software/daq_configuration/"),
+        Path("/dls_sw/i04/software/daq_configuration/"),
     }
     assert expected_files.issubset(whitelist.whitelist_files)
     assert expected_dirs.issubset(whitelist.whitelist_dirs)

--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -14,11 +14,9 @@ whitelist_files:
 - /tests/test_data/beamline_parameters.txt
 # The following filepaths should be un-whitelisted once they've been moved to **/daq_configuration/
 # See https://jira.diamond.ac.uk/browse/MXGDA-4204
-- /dls_sw/i03/software/gda/configurations/i03-config/xml/jCameraManZoomLevels.xml
 - /dls_sw/i04/software/bluesky/scratch/jCameraManZoomLevels.xml
 - /dls_sw/i19-1/software/gda_versions/gda/config/xml/jCameraManZoomLevels.xml
 - /dls_sw/i24/software/gda_versions/gda/config/xml/jCameraManZoomLevels.xml
-- /dls_sw/i03/software/gda_versions/var/display.configuration
 - /dls_sw/i04/software/bluesky/scratch/display.configuration
 - /dls_sw/i23/software/aithre/aithre_display.configuration
 - /dls_sw/i24/software/gda_versions/var/display.configuration
@@ -28,7 +26,6 @@ whitelist_files:
 whitelist_dirs:
 - /tests/test_data/
 - /dls_sw/i02-1/software/daq_configuration/
-- /dls_sw/i03/software/daq_configuration/
 - /dls_sw/i04/software/daq_configuration/
 - /dls_sw/i19-1/software/daq_configuration/
 - /dls_sw/i19-2/software/daq_configuration/


### PR DESCRIPTION
This removes all references to paths on i03 from files as i03 configuration is done in `i03-services` values.yaml

