### PR TITLE
Move config_mock to constructor

### DIFF
--- a/docs/how-to/config-server-guide.md
+++ b/docs/how-to/config-server-guide.md
@@ -83,7 +83,7 @@ To use the mock server with local configuration files, create a `MockServerRespo
 
 ```python
 from daq_config_server.client import ConfigClient
-from daq_config_server.testing.
+from daq_config_server.testing import MockServerResponse
 
 config_client = ConfigClient(
     server_response=MockServerResponse(),

--- a/docs/how-to/config-server-guide.md
+++ b/docs/how-to/config-server-guide.md
@@ -108,11 +108,7 @@ For example:
 
 ```python
 config_client = ConfigClient(
-    server_response=MockServerResponse(
-        {
-            "/path/to/data.txt": {"key": "value"},
-        }
-    ),
+    server_response=MockServerResponse({"/path/to/data.txt": {"key": "value"}}),
 )
 ```
 
@@ -124,11 +120,7 @@ You can configure the mock server to return a `ConfigModel` instance directly:
 expected = MyModel(field="value")
 
 client = ConfigClient(
-    server_response=MockServerResponse(
-        {
-            "/path/to/data.txt": expected,
-        }
-    ),
+    server_response=MockServerResponse({"/path/to/data.txt": expected}),
 )
 
 result = client.get_file_contents(
@@ -150,11 +142,7 @@ expected = {
 }
 
 client = ConfigClient(
-    server_response=MockServerResponse(
-        {
-            "/path/to/data.txt": expected,
-        }
-    ),
+    server_response=MockServerResponse({"/path/to/data.txt": expected})
 )
 
 result = client.get_file_contents(

--- a/docs/how-to/config-server-guide.md
+++ b/docs/how-to/config-server-guide.md
@@ -67,49 +67,54 @@ If you need to read a file which contains sensitive information, or `dls-dasc` d
 
 # Mocking the Config Client (for tests and offline development)
 
-The `ConfigClient` can be configured to run in a fully offline mode for unit tests and local development. In this mode, no HTTP requests are made. Instead, responses for specific file paths can be overridden with mock data.
+The `ConfigClient` can be configured to run in a fully offline mode for unit tests and local development. In this mode, no HTTP requests are made. Instead, responses are read from the local filesystem, with the option to override specific file paths with mock data.
 
-Mock data can be provided as a `ConfigModel`, `dict`, `str`, or `bytes`, allowing tests to simulate the responses that would normally be returned by the config server without requiring a running service or real configuration files.
+Mock data can be provided as a `ConfigModel`, `dict`, `str`, or `bytes`, allowing tests to simulate responses that would normally be returned by the config server without requiring a running service or real configuration files.
 
 ## Enabling mock mode
 
+Mock mode is configured when constructing the `ConfigClient` by passing `mock=True`:
+
 ```python
-config_client = ConfigClient()
-config_client.configure_mock()
+config_client = ConfigClient(mock=True)
 ```
 
-With no mock data configured, the client reads directly from the local filesystem instead of contacting the config server.
+With no mock data configured, the client reads requested files directly from the local filesystem instead of contacting the config server.
 
 ### Mock data
 
-Mock mode allows you to override the contents returned for specific files without running a real config server.
+You can override the contents returned for specific files by passing a mapping of file paths to mock data when constructing the client.
 
 When a mocked path is requested, the configured value is returned. For all other paths, the client reads the file contents from the local filesystem.
 
-Mock data is registered as a mapping from `str` file path to the value that should be returned. Supported values are:
+Mock data is provided as a mapping from `str` file path to the value that should be returned. Supported values are:
 
 ```python
 ConfigModel | str | bytes | dict[str, Any]
 ```
 
-```python
+For example:
 
-config_client.configure_mock(
-    {
-        "/path/to/data.txt": {"key": "value"}
+```python
+config_client = ConfigClient(
+    mock={
+        "/path/to/data.txt": {"key": "value"},
     }
 )
 ```
 
 ### Example: returning a model
 
-You can configure the mock to return a `ConfigModel` instance directly.
+You can configure the mock to return a `ConfigModel` instance directly:
 
 ```python
-
 expected = MyModel(field="value")
 
-client.configure_mock({"/path/to/data.txt": expected})
+client = ConfigClient(
+    mock={
+        "/path/to/data.txt": expected,
+    }
+)
 
 result = client.get_file_contents(
     "/path/to/data.txt",
@@ -121,18 +126,26 @@ assert result == expected
 
 ### Example: returning a dictionary
 
-If the caller requests a dictionary, provide a dictionary as the mock data.
+If the caller requests a dictionary, provide a dictionary as the mock data:
 
 ```python
-
 expected = {
     "x": 1,
     "y": "test",
 }
 
-client.configure_mock({"/path/to/data.txt": expected})
+client = ConfigClient(
+    mock={
+        "/path/to/data.txt": expected,
+    }
+)
 
-result = client.get_file_contents("/path/to/data.txt", desired_return_type=dict)
+result = client.get_file_contents(
+    "/path/to/data.txt",
+    desired_return_type=dict,
+)
 
 assert result == expected
 ```
+
+Mock mode is configured for the lifetime of the `ConfigClient` instance. It cannot be enabled or disabled after construction, preventing one test or plan from changing the behaviour of a shared client used by subsequent tests or plans.

--- a/docs/how-to/config-server-guide.md
+++ b/docs/how-to/config-server-guide.md
@@ -8,7 +8,7 @@ This library provides a python client to easily make requests from Bluesky code.
 ```python
 from daq_config_server.client import ConfigClient
 
-config_client = ConfigClient("https://daq-config.diamond.ac.uk", cache_size = 10, cache_lifetime_s = 3600)
+config_client = ConfigClient.from_url("https://daq-config.diamond.ac.uk", cache_size = 10, cache_lifetime_s = 3600)
 ```
 
 You can then make a request through this client through its `get_file_contents` function. If you are reading a file which may have changed since the client last read it, you should set the appropriate flag to reset the cache for that result - this forces a new request and stores that new result in the cache.
@@ -67,23 +67,34 @@ If you need to read a file which contains sensitive information, or `dls-dasc` d
 
 # Mocking the Config Client (for tests and offline development)
 
-The `ConfigClient` can be configured to run in a fully offline mode for unit tests and local development. In this mode, no HTTP requests are made. Instead, responses are read from the local filesystem, with the option to override specific file paths with mock data.
+The `ConfigClient` supports offline testing and development by allowing the server response implementation to be provided when the client is constructed.
 
-Mock data can be provided as a `ConfigModel`, `dict`, `str`, or `bytes`, allowing tests to simulate responses that would normally be returned by the config server without requiring a running service or real configuration files.
-
-## Enabling mock mode
-
-Mock mode is configured when constructing the `ConfigClient` by passing `mock=True`:
+In normal use, create a client using `ConfigClient.from_url()`. This creates a client backed by a real configuration server:
 
 ```python
-config_client = ConfigClient(mock=True)
+config_client = ConfigClient.from_url()
 ```
 
-With no mock data configured, the client reads requested files directly from the local filesystem instead of contacting the config server.
+For tests and offline development, construct the client with a `MockServerResponse` instead. No HTTP requests are made; responses are read from the local filesystem, with the option to override specific file paths with mock data.
+
+## Mock server
+
+To use the mock server with local configuration files, create a `MockServerResponse` and pass it to the `ConfigClient`:
+
+```python
+from daq_config_server.client import ConfigClient
+from daq_config_server.testing.
+
+config_client = ConfigClient(
+    server_response=MockServerResponse(),
+)
+```
+
+With no mock data configured, requested configuration files are read directly from the local filesystem.
 
 ### Mock data
 
-You can override the contents returned for specific files by passing a mapping of file paths to mock data when constructing the client.
+You can override the contents returned for specific files by passing a mapping of file paths to mock data to `MockServerResponse`.
 
 When a mocked path is requested, the configured value is returned. For all other paths, the client reads the file contents from the local filesystem.
 
@@ -97,23 +108,27 @@ For example:
 
 ```python
 config_client = ConfigClient(
-    mock={
-        "/path/to/data.txt": {"key": "value"},
-    }
+    server_response=MockServerResponse(
+        {
+            "/path/to/data.txt": {"key": "value"},
+        }
+    ),
 )
 ```
 
 ### Example: returning a model
 
-You can configure the mock to return a `ConfigModel` instance directly:
+You can configure the mock server to return a `ConfigModel` instance directly:
 
 ```python
 expected = MyModel(field="value")
 
 client = ConfigClient(
-    mock={
-        "/path/to/data.txt": expected,
-    }
+    server_response=MockServerResponse(
+        {
+            "/path/to/data.txt": expected,
+        }
+    ),
 )
 
 result = client.get_file_contents(
@@ -135,9 +150,11 @@ expected = {
 }
 
 client = ConfigClient(
-    mock={
-        "/path/to/data.txt": expected,
-    }
+    server_response=MockServerResponse(
+        {
+            "/path/to/data.txt": expected,
+        }
+    ),
 )
 
 result = client.get_file_contents(
@@ -148,4 +165,4 @@ result = client.get_file_contents(
 assert result == expected
 ```
 
-Mock mode is configured for the lifetime of the `ConfigClient` instance. It cannot be enabled or disabled after construction, preventing one test or plan from changing the behaviour of a shared client used by subsequent tests or plans.
+The server response implementation is selected when the `ConfigClient` is constructed and cannot be changed afterwards. This ensures that a test or plan cannot switch a shared client between real and mock behaviour at runtime.

--- a/src/daq_config_server/client/__init__.py
+++ b/src/daq_config_server/client/__init__.py
@@ -1,3 +1,4 @@
 from ._client import ConfigClient
+from ._server_response import ResponseProtocol, ServerResponse
 
-__all__ = ["ConfigClient"]
+__all__ = ["ConfigClient", "ResponseProtocol", "ServerResponse"]

--- a/src/daq_config_server/client/_client.py
+++ b/src/daq_config_server/client/_client.py
@@ -8,7 +8,6 @@ from typing import Any, TypeVar, get_origin, overload
 
 from cachetools import TTLCache, cachedmethod
 from pydantic import TypeAdapter
-from requests import Response
 
 from daq_config_server.app.constants import EndPoints, ValidAcceptHeaders
 from daq_config_server.models.base_model import ConfigModel
@@ -60,6 +59,7 @@ class ConfigClient:
         log: Logger | None = None,
         cache_size: int = 10,
         cache_lifetime_s: int = 3600,
+        mock: bool | PathToMockDataDict = False,
     ) -> None:
         """
         Args:
@@ -67,32 +67,22 @@ class ConfigClient:
             log: Optional logger instance.
             cache_size: Size of the cache (maximum number of items can be stored).
             cache_lifetime_s: Lifetime of the cache (in seconds).
+            mock: Configure the client to use mock responses instead of the config
+                server. If True, requested configuration files are read from the
+                local filesystem. If a mapping is provided, files are read from
+                the local filesystem unless their path is present in the mapping,
+                in which case the provided configuration is returned instead.
         """
 
         self._url = url.rstrip("/")
         self._log = log or getLogger("daq_config_server.client")
-        self._cache: TTLCache[tuple[str, str, Path], Response] = TTLCache(
-            maxsize=cache_size, ttl=cache_lifetime_s
-        )
+        self._cache = TTLCache(maxsize=cache_size, ttl=cache_lifetime_s)
         self._lock = RLock()
-        self._server: ServerResponse = RealServerResponse(self._url, self._log)
-
-    def configure_mock(
-        self, path_to_mock_data: PathToMockDataDict | None = None
-    ) -> None:
-        """Switch the client into mock mode using a local filesystem backend.
-
-        This replaces the real HTTP server implementation with a mock
-        server that reads configuration data directly from local files.
-
-        Optional converters can be provided to simulate server-side parsing
-        or transformation logic on a per-file basis.
-
-        Args:
-            path_to_mock_data:
-                Optional mapping of file paths to mock data to return from the server.
-        """
-        self._server = MockServerResponse(path_to_mock_data)
+        self._server: ServerResponse
+        if mock is False:
+            self._server = RealServerResponse(self._url, self._log)
+        else:
+            self._server = MockServerResponse(mock if isinstance(mock, dict) else None)
 
     @cachedmethod(
         cache=operator.attrgetter("_cache"), lock=operator.attrgetter("_lock")

--- a/src/daq_config_server/client/_client.py
+++ b/src/daq_config_server/client/_client.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from logging import Logger, getLogger
 from pathlib import Path
 from threading import RLock
-from typing import Any, Final, TypeVar, get_origin, overload
+from typing import Any, Final, Self, TypeVar, get_origin, overload
 
 from cachetools import TTLCache, cachedmethod
 from pydantic import TypeAdapter
@@ -14,10 +14,8 @@ from daq_config_server.app.constants import EndPoints, ValidAcceptHeaders
 from daq_config_server.models.base_model import ConfigModel
 
 from ._server_response import (
-    MockServerResponse,
-    PathToMockDataDict,
     RealServerResponse,
-    ResponseType,
+    ResponseProtocol,
     ServerResponse,
 )
 
@@ -56,43 +54,49 @@ class ConfigClient:
 
     def __init__(
         self,
-        url: str = "https://daq-config.diamond.ac.uk",
+        server_response: ServerResponse,
         log: Logger | None = None,
         cache_size: int = 10,
         cache_lifetime_s: int = 3600,
-        mock: bool | PathToMockDataDict = False,
     ) -> None:
         """
         Args:
-            url: Base URL of the config server. Defaults to central service.
+            server_response: Backend used to retrieve configuration data from.
             log: Optional logger instance.
             cache_size: Size of the cache (maximum number of items can be stored).
             cache_lifetime_s: Lifetime of the cache (in seconds).
-            mock: Configure the client to use mock responses instead of the config
-                server. If True, requested configuration files are read from the
-                local filesystem. If a mapping is provided, files are read from
-                the local filesystem unless their path is present in the mapping,
-                in which case the provided configuration is returned instead.
         """
-
-        self._url = url.rstrip("/")
         self._log = log or getLogger("daq_config_server.client")
         self._cache = TTLCache[tuple[str, str, Path], Response](
             maxsize=cache_size, ttl=cache_lifetime_s
         )
         self._lock = RLock()
-        self._server: Final[ServerResponse]
-        if mock is False:
-            self._server = RealServerResponse(self._url, self._log)
-        else:
-            self._server = MockServerResponse(mock if isinstance(mock, dict) else None)
+        self._server: Final[ServerResponse] = server_response
+
+    @classmethod
+    def from_url(
+        cls,
+        url: str = "https://daq-config.diamond.ac.uk",
+        log: Logger | None = None,
+        cache_size: int = 10,
+        cache_lifetime_s: int = 3600,
+    ) -> Self:
+        """Create a ConfigClient that retrieves data from the given URL.
+        Defaults to the central configuration service.
+        """
+        return cls(
+            log=log,
+            cache_size=cache_size,
+            cache_lifetime_s=cache_lifetime_s,
+            server_response=RealServerResponse(url),
+        )
 
     @cachedmethod(
         cache=operator.attrgetter("_cache"), lock=operator.attrgetter("_lock")
     )
     def _cached_get(
         self, endpoint: str, accept_header: ValidAcceptHeaders, file_path: Path
-    ) -> ResponseType:
+    ) -> ResponseProtocol:
         """
         Get data from the config server and cache it.
 
@@ -104,10 +108,14 @@ class ConfigClient:
         Returns:
             The response data.
         """
-        request_url = self._url + endpoint + (f"/{file_path}")
-        r = self._server.get_response(endpoint, accept_header, file_path)
-        self._log.debug(f"Cache set for {request_url}.")
-        return r
+        request_url = self._server.url + endpoint + (f"/{file_path}")
+        try:
+            r = self._server.get_response(endpoint, accept_header, file_path)
+            self._log.debug(f"Cache set for {request_url}.")
+            return r
+        except Exception as e:
+            self._log.error(e)
+            raise e
 
     def _get(
         self,

--- a/src/daq_config_server/client/_client.py
+++ b/src/daq_config_server/client/_client.py
@@ -8,6 +8,7 @@ from typing import Any, Final, TypeVar, get_origin, overload
 
 from cachetools import TTLCache, cachedmethod
 from pydantic import TypeAdapter
+from requests import Response
 
 from daq_config_server.app.constants import EndPoints, ValidAcceptHeaders
 from daq_config_server.models.base_model import ConfigModel
@@ -76,7 +77,9 @@ class ConfigClient:
 
         self._url = url.rstrip("/")
         self._log = log or getLogger("daq_config_server.client")
-        self._cache = TTLCache(maxsize=cache_size, ttl=cache_lifetime_s)
+        self._cache = TTLCache[tuple[str, str, Path], Response](
+            maxsize=cache_size, ttl=cache_lifetime_s
+        )
         self._lock = RLock()
         self._server: Final[ServerResponse]
         if mock is False:

--- a/src/daq_config_server/client/_client.py
+++ b/src/daq_config_server/client/_client.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from logging import Logger, getLogger
 from pathlib import Path
 from threading import RLock
-from typing import Any, TypeVar, get_origin, overload
+from typing import Any, Final, TypeVar, get_origin, overload
 
 from cachetools import TTLCache, cachedmethod
 from pydantic import TypeAdapter
@@ -78,7 +78,7 @@ class ConfigClient:
         self._log = log or getLogger("daq_config_server.client")
         self._cache = TTLCache(maxsize=cache_size, ttl=cache_lifetime_s)
         self._lock = RLock()
-        self._server: ServerResponse
+        self._server: Final[ServerResponse]
         if mock is False:
             self._server = RealServerResponse(self._url, self._log)
         else:
@@ -101,7 +101,6 @@ class ConfigClient:
         Returns:
             The response data.
         """
-
         request_url = self._url + endpoint + (f"/{file_path}")
         r = self._server.get_response(endpoint, accept_header, file_path)
         self._log.debug(f"Cache set for {request_url}.")

--- a/src/daq_config_server/client/_server_response.py
+++ b/src/daq_config_server/client/_server_response.py
@@ -1,5 +1,4 @@
-import json
-from logging import Logger
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -8,51 +7,19 @@ from requests import Response as RealResponse
 from requests.exceptions import HTTPError
 
 from daq_config_server.app.constants import ValidAcceptHeaders
-from daq_config_server.models.base_model import ConfigModel
-
-NonModel = str | bytes | dict[str, Any]
-PathToMockDataDict = dict[str, ConfigModel | NonModel]
 
 
-class MockResponse:
-    """Lightweight stand-in for requests.Response used in unit tests.
-
-    This class emulates the minimal interface of a real HTTP response
-    required by ConfigClient, without performing any network operations.
-
-    This allows tests to simulate server responses at different encoding
-    layers (JSON, plain text, or raw bytes) while keeping behaviour
-    consistent with real requests.Response objects.
-    """
-
-    def __init__(
-        self,
-        body: str | bytes,
-        content_type: ValidAcceptHeaders,
-    ):
-        self.headers = {"content-type": content_type}
-        self._body = body
-
-    def json(self) -> Any:
-        """Match requests.Response: JSON is parsed from text/bytes."""
-        if isinstance(self._body, bytes):
-            return json.loads(self._body.decode())
-        return json.loads(self._body)
+class ResponseProtocol(Protocol):
+    def json(self) -> Any: ...
 
     @property
-    def text(self) -> str:
-        if isinstance(self._body, bytes):
-            return self._body.decode()
-        return self._body
+    def headers(self) -> Mapping[str, str]: ...
 
     @property
-    def content(self) -> bytes:
-        if isinstance(self._body, bytes):
-            return self._body
-        return self._body.encode()
+    def text(self) -> str: ...
 
-
-ResponseType = RealResponse | MockResponse
+    @property
+    def content(self) -> bytes: ...
 
 
 class ServerResponse(Protocol):
@@ -60,38 +27,11 @@ class ServerResponse(Protocol):
     mock implementation.
     """
 
-    def get_response(
-        self, endpoint: str, accept_header: ValidAcceptHeaders, file_path: Path
-    ) -> ResponseType: ...
-
-
-class MockServerResponse(ServerResponse):
-    """Mock implementation of ServerResponse used for unit testing.
-
-    This class simulates a config server by reading local files instead of performing
-    HTTP requests. Supports optional overrides for a specified path to the data you
-    want to return instead.
-    """
-
-    def __init__(self, path_to_mock_data: PathToMockDataDict | None = None):
-        self.path_to_mock_data = path_to_mock_data or {}
+    url: str
 
     def get_response(
         self, endpoint: str, accept_header: ValidAcceptHeaders, file_path: Path
-    ) -> MockResponse:
-        if str(file_path) in self.path_to_mock_data:
-            mock_data = self.path_to_mock_data[str(file_path)]
-            if isinstance(mock_data, ConfigModel):
-                mock_response = mock_data.model_dump_json()
-            elif isinstance(mock_data, dict):
-                mock_response = json.dumps(mock_data)
-            elif isinstance(mock_data, bytes):
-                mock_response = mock_data.decode()
-            else:
-                mock_response = mock_data
-        else:
-            mock_response = file_path.read_text()
-        return MockResponse(mock_response, accept_header)
+    ) -> ResponseProtocol: ...
 
 
 class RealServerResponse(ServerResponse):
@@ -101,13 +41,12 @@ class RealServerResponse(ServerResponse):
     requests and retrieves file contents from a deployed service.
     """
 
-    def __init__(self, url: str, log: Logger):
-        self._url = url
-        self._log = log
+    def __init__(self, url: str = "https://daq-config.diamond.ac.uk"):
+        self.url = url
 
     def get_response(
         self, endpoint: str, accept_header: ValidAcceptHeaders, file_path: Path
-    ) -> ResponseType:
+    ) -> RealResponse:
         """
         Get data from the config server and cache it.
 
@@ -120,7 +59,7 @@ class RealServerResponse(ServerResponse):
             The response data.
         """
 
-        request_url = self._url + endpoint + (f"/{file_path}")
+        request_url = self.url + endpoint + (f"/{file_path}")
         r = requests.get(request_url, headers={"Accept": accept_header})
         # Intercept http exceptions from server so that the client
         # can include the response `detail` sent by the server
@@ -129,9 +68,11 @@ class RealServerResponse(ServerResponse):
         except requests.exceptions.HTTPError as err:
             try:
                 error_detail = r.json().get("detail")
-                self._log.error(error_detail)
-                raise HTTPError(error_detail) from err
             except ValueError:
-                self._log.error("Response raised HTTP error but no details provided")
-                raise HTTPError from err
+                error_detail = None
+
+            if error_detail is None:
+                error_detail = "Response raised HTTP error but no details provided"
+            raise HTTPError(error_detail) from err
+
         return r

--- a/src/daq_config_server/testing/__init__.py
+++ b/src/daq_config_server/testing/__init__.py
@@ -1,3 +1,15 @@
 from ._utils import make_test_response
+from .mock_server_response import (
+    MockResponse,
+    MockServerResponse,
+    NonModel,
+    PathToMockDataDict,
+)
 
-__all__ = ["make_test_response"]
+__all__ = [
+    "make_test_response",
+    "MockResponse",
+    "MockServerResponse",
+    "NonModel",
+    "PathToMockDataDict",
+]

--- a/src/daq_config_server/testing/mock_server_response.py
+++ b/src/daq_config_server/testing/mock_server_response.py
@@ -1,0 +1,83 @@
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from daq_config_server.app.constants import ValidAcceptHeaders
+from daq_config_server.client import ResponseProtocol, ServerResponse
+from daq_config_server.models.base_model import ConfigModel
+
+NonModel = str | bytes | dict[str, Any]
+PathToMockDataDict = dict[str, ConfigModel | NonModel]
+
+
+class MockResponse(ResponseProtocol):
+    """Lightweight stand-in for requests.Response used in unit tests.
+
+    This class emulates the minimal interface of a real HTTP response
+    required by ConfigClient, without performing any network operations.
+
+    This allows tests to simulate server responses at different encoding
+    layers (JSON, plain text, or raw bytes) while keeping behaviour
+    consistent with real requests.Response objects.
+    """
+
+    def __init__(
+        self,
+        body: str | bytes,
+        content_type: ValidAcceptHeaders,
+    ):
+        self._headers = {"content-type": content_type}
+        self._body = body
+
+    @property
+    def headers(self) -> Mapping[str, ValidAcceptHeaders]:
+        return self._headers
+
+    def json(self) -> Any:
+        """Match requests.Response: JSON is parsed from text/bytes."""
+        if isinstance(self._body, bytes):
+            return json.loads(self._body.decode())
+        return json.loads(self._body)
+
+    @property
+    def text(self) -> str:
+        if isinstance(self._body, bytes):
+            return self._body.decode()
+        return self._body
+
+    @property
+    def content(self) -> bytes:
+        if isinstance(self._body, bytes):
+            return self._body
+        return self._body.encode()
+
+
+class MockServerResponse(ServerResponse):
+    """Mock implementation of ServerResponse used for unit testing.
+
+    This class simulates a config server by reading local files instead of performing
+    HTTP requests. Supports optional overrides for a specified path to the data you
+    want to return instead.
+    """
+
+    def __init__(self, path_to_mock_data: PathToMockDataDict | None = None):
+        self.path_to_mock_data = path_to_mock_data or {}
+        self.url = "mock-url"
+
+    def get_response(
+        self, endpoint: str, accept_header: ValidAcceptHeaders, file_path: Path
+    ) -> MockResponse:
+        if str(file_path) in self.path_to_mock_data:
+            mock_data = self.path_to_mock_data[str(file_path)]
+            if isinstance(mock_data, ConfigModel):
+                mock_response = mock_data.model_dump_json()
+            elif isinstance(mock_data, dict):
+                mock_response = json.dumps(mock_data)
+            elif isinstance(mock_data, bytes):
+                mock_response = mock_data.decode()
+            else:
+                mock_response = mock_data
+        else:
+            mock_response = file_path.read_text()
+        return MockResponse(mock_response, accept_header)

--- a/tests/system_tests/test_client.py
+++ b/tests/system_tests/test_client.py
@@ -112,14 +112,16 @@ def test_bad_json_gives_http_error_with_details(client: ConfigClient):
         f"Failed to convert {file_name} to application/json. "
         "Try requesting this file as a different type."
     )
-
     client._log.error = MagicMock()
-    with pytest.raises(requests.exceptions.HTTPError):
+
+    with pytest.raises(requests.exceptions.HTTPError, match=expected_detail):
         client.get_file_contents(
             file_path,
             dict[Any, Any],
         )
-    client._log.error.assert_called_once_with(expected_detail)
+    logged_error = client._log.error.call_args.args[0]
+    assert isinstance(logged_error, requests.exceptions.HTTPError)
+    assert str(logged_error) == expected_detail
 
 
 @pytest.mark.requires_local_server

--- a/tests/system_tests/test_client.py
+++ b/tests/system_tests/test_client.py
@@ -33,12 +33,12 @@ DEPLOYED_SERVER_ADDRESS = "https://daq-config.diamond.ac.uk"
 
 @pytest.fixture
 def client():
-    return ConfigClient(SERVER_ADDRESS)
+    return ConfigClient.from_url(SERVER_ADDRESS)
 
 
 @pytest.fixture
 def deployed_client():
-    return ConfigClient(DEPLOYED_SERVER_ADDRESS)
+    return ConfigClient.from_url(DEPLOYED_SERVER_ADDRESS)
 
 
 @pytest.fixture

--- a/tests/unit_tests/client/test_client.py
+++ b/tests/unit_tests/client/test_client.py
@@ -17,7 +17,6 @@ from daq_config_server.client._client import (
     TypeConversionError,
     _get_mime_type,
 )
-from daq_config_server.client._server_response import NonModel
 from daq_config_server.models import ConfigModel, DisplayConfig
 from daq_config_server.models.lookup_tables import (
     BeamlinePitchLookupTable,
@@ -26,7 +25,7 @@ from daq_config_server.models.lookup_tables import (
 from daq_config_server.models.lookup_tables.insertion_device import (
     UndulatorEnergyGapLookupTable,
 )
-from daq_config_server.testing import make_test_response
+from daq_config_server.testing import MockServerResponse, NonModel, make_test_response
 
 REQUEST_PATCH = "daq_config_server.client._server_response.requests.get"
 
@@ -35,7 +34,7 @@ test_path = Path("test")
 
 @pytest.fixture
 def client() -> ConfigClient:
-    return ConfigClient("url")
+    return ConfigClient.from_url("url")
 
 
 @patch(REQUEST_PATCH)
@@ -49,7 +48,7 @@ def test_config_client_get_file_contents_default_header(
     mock_request.return_value = make_test_response("test")
     assert client.get_file_contents(test_path) == "test"
     mock_request.assert_called_once_with(
-        client._url + EndPoints.CONFIG + "/" + str(test_path),
+        client._server.url + EndPoints.CONFIG + "/" + str(test_path),
         headers={"Accept": ValidAcceptHeaders.PLAIN_TEXT},
     )
 
@@ -107,9 +106,10 @@ def test_config_client_bad_responses_no_details_raises_error(
     client._log.error = MagicMock()
     with pytest.raises(requests.exceptions.HTTPError):
         client.get_file_contents(test_path)
-    client._log.error.assert_called_once_with(
-        "Response raised HTTP error but no details provided"
-    )
+
+    logged_error = client._log.error.call_args.args[0]
+    assert isinstance(logged_error, requests.exceptions.HTTPError)
+    assert str(logged_error) == "Response raised HTTP error but no details provided"
 
 
 @patch(REQUEST_PATCH)
@@ -117,7 +117,6 @@ def test_config_client_bad_responses_with_details_raises_error(
     mock_request: MagicMock, client: ConfigClient
 ):
     """Test that a non-200 response raises a RequestException."""
-
     detail = "test detail"
     mock_request.return_value = make_test_response(
         "1st_read",
@@ -127,9 +126,15 @@ def test_config_client_bad_responses_with_details_raises_error(
     )
     mock_request.return_value.json = MagicMock(return_value={"detail": detail})
     client._log.error = MagicMock()
+
     with pytest.raises(requests.exceptions.HTTPError):
         client.get_file_contents(test_path)
-    client._log.error.assert_called_once_with(detail)
+
+    client._log.error.assert_called_once()
+    logged_error = client._log.error.call_args.args[0]
+
+    assert isinstance(logged_error, requests.exceptions.HTTPError)
+    assert str(logged_error) == detail
 
 
 @patch(REQUEST_PATCH)
@@ -236,7 +241,7 @@ def test_config_client_get_file_contents_with_bad_force_parser_errors(
 def test_reset_cache(mock_request: MagicMock):
     mock_config = "Units eV mm\n5700		5.4606\n#24500		7.2\n"
     mock_request.return_value = make_test_response(mock_config)
-    server = ConfigClient("url")
+    server = ConfigClient.from_url("url")
     result = server.get_file_contents(test_path, str)
 
     assert server._cache.currsize == 1
@@ -252,7 +257,7 @@ def test_reset_cache(mock_request: MagicMock):
     assert result != new_result
 
 
-def test_mock_config_client_get_file_contents_as_dict_gives_expected_result(
+def test_config_client_with_mock_server_get_file_contents_as_dict_gives_expected_result(
     tmp_path: Path,
 ):
     file = tmp_path / "beamline.json"
@@ -260,13 +265,13 @@ def test_mock_config_client_get_file_contents_as_dict_gives_expected_result(
     expected_data = {"x": 1, "y": "test"}
     file.write_text(json.dumps(expected_data))
 
-    client = ConfigClient(mock=True)
+    client = ConfigClient(server_response=MockServerResponse())
 
     result = client.get_file_contents(file, desired_return_type=dict)
     assert result == expected_data
 
 
-def test_mock_config_client_get_file_contents_as_str_gives_expected_result(
+def test_config_client_with_mock_server_get_file_contents_as_str_gives_expected_result(
     tmp_path: Path,
 ):
     file = tmp_path / "beamline.json"
@@ -274,7 +279,7 @@ def test_mock_config_client_get_file_contents_as_str_gives_expected_result(
     expected_data = '{"x": 1, "y": "test"}'
     file.write_text(expected_data)
 
-    client = ConfigClient(mock=True)
+    client = ConfigClient(server_response=MockServerResponse())
 
     result = client.get_file_contents(file)
     assert result == expected_data
@@ -286,14 +291,14 @@ class MyModel(ConfigModel):
     z: list[int] = [1, 4, 5]
 
 
-def test_mock_config_client_get_file_contents_as_config_model_gives_expected_result(
+def test_config_client_with_mock_server_file_contents_gives_expected_result(
     tmp_path: Path,
 ):
     real_file = tmp_path / "beamline.json"
     expected_data = MyModel().model_dump_json()
     real_file.write_text(expected_data)
 
-    client = ConfigClient(mock=True)
+    client = ConfigClient(server_response=MockServerResponse())
 
     result = client.get_file_contents(real_file)
     assert result == expected_data
@@ -308,14 +313,15 @@ def test_mock_config_client_get_file_contents_as_config_model_gives_expected_res
         (b"My string data", bytes),
     ),
 )
-def test_mock_config_client_with_path_to_data_override(
+def test_config_client_with_mock_server_path_to_data_override(
     expected_data: ConfigModel | NonModel,
     return_type: type[ConfigModel | NonModel],
 ):
     mock_file = "/path/to/data.txt"
 
-    client = ConfigClient(mock={mock_file: expected_data})
-
+    client = ConfigClient(
+        server_response=MockServerResponse({mock_file: expected_data})
+    )
     result = client.get_file_contents(mock_file, desired_return_type=return_type)
     assert result == expected_data
 

--- a/tests/unit_tests/client/test_client.py
+++ b/tests/unit_tests/client/test_client.py
@@ -260,8 +260,7 @@ def test_mock_config_client_get_file_contents_as_dict_gives_expected_result(
     expected_data = {"x": 1, "y": "test"}
     file.write_text(json.dumps(expected_data))
 
-    client = ConfigClient()
-    client.configure_mock()
+    client = ConfigClient(mock=True)
 
     result = client.get_file_contents(file, desired_return_type=dict)
     assert result == expected_data
@@ -275,8 +274,7 @@ def test_mock_config_client_get_file_contents_as_str_gives_expected_result(
     expected_data = '{"x": 1, "y": "test"}'
     file.write_text(expected_data)
 
-    client = ConfigClient()
-    client.configure_mock()
+    client = ConfigClient(mock=True)
 
     result = client.get_file_contents(file)
     assert result == expected_data
@@ -295,8 +293,7 @@ def test_mock_config_client_get_file_contents_as_config_model_gives_expected_res
     expected_data = MyModel().model_dump_json()
     real_file.write_text(expected_data)
 
-    client = ConfigClient()
-    client.configure_mock()
+    client = ConfigClient(mock=True)
 
     result = client.get_file_contents(real_file)
     assert result == expected_data
@@ -317,8 +314,7 @@ def test_mock_config_client_with_path_to_data_override(
 ):
     mock_file = "/path/to/data.txt"
 
-    client = ConfigClient()
-    client.configure_mock({mock_file: expected_data})
+    client = ConfigClient(mock={mock_file: expected_data})
 
     result = client.get_file_contents(mock_file, desired_return_type=return_type)
     assert result == expected_data

--- a/tests/unit_tests/testing/test_mock_server_response.py
+++ b/tests/unit_tests/testing/test_mock_server_response.py
@@ -1,7 +1,7 @@
 import json
 
 from daq_config_server.app._routes import ValidAcceptHeaders
-from daq_config_server.client._server_response import MockResponse
+from daq_config_server.testing.mock_server_response import MockResponse
 
 
 def test_mock_response_using_bytes():

--- a/tests/unit_tests/testing/test_mock_server_response.py
+++ b/tests/unit_tests/testing/test_mock_server_response.py
@@ -1,7 +1,7 @@
 import json
 
 from daq_config_server.app._routes import ValidAcceptHeaders
-from daq_config_server.testing.mock_server_response import MockResponse
+from daq_config_server.testing import MockResponse
 
 
 def test_mock_response_using_bytes():


### PR DESCRIPTION
As discussed with @Relm-Arrowny, you could accidentally call configure_mock from a plan and then it will forever be struck in mock mode reading from the blueapi pod files. Updated this so that if mock mode is required, it is done at constructor level and cannot be changed after it has been initialised.

This now means you cannot accidentally switch between mock and prod code during the lifetime of the object.