### PR TITLE
Add i19 lookup tables to converter map

### DIFF
--- a/helm/daq-config-server/converter_map.yaml
+++ b/helm/daq-config-server/converter_map.yaml
@@ -60,3 +60,9 @@
   converter: TemperatureControllersConfig
 - path: "/dls_sw/i15-1/software/daq_configuration/xpdf_crystal_lut.txt"
   converter: XpdfCrystalLookupTable
+- path: "/dls_sw/i19-2/software/daq_configuration/lookup/DetDistToBeamXYConverterE4M.txt"
+  converter: DetectorXYLookupTable
+- path: "/dls_sw/i19-2/software/daq_configuration/lookup/DetDistToBeamXYConverterTristan.txt"
+  converter: DetectorXYLookupTable
+- path: "/dls_sw/i19-1/software/i19-acquisition/i19-shared/lookup/energy_to_id_gap_look_up_table.txt"
+  converter: UndulatorEnergyGapLookupTable


### PR DESCRIPTION
Some missing i19-2 and i19-shared (optics) lookup tables to converter map